### PR TITLE
Upgrade markdown config 🖋

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,16 +15,23 @@ module.exports = function(eleventyConfig) {
 
   // Shortcodes
   eleventyConfig.addPairedShortcode('smallCaps', (content) => `<span class="sc">${content}</span>`);
-  const figure = ([ image, alt, caption, link, label ], args = {}) => {
+
+  const figure = ([ image, size, alt, caption, link, label ], args = {}) => {
     const { layout } = args;
     let captionMarkup = '';
+
+    const [width, height] = (size || '').split('x');
+
+    console.log(width, height);
 
     if (caption) {
       const linkMarkup = link ? ` <a class="figure__link" href="${link}" target="_blank" rel="noopener">${label}</a>` : '';
       captionMarkup = `<figcaption class="figure__caption">${caption}${linkMarkup}</figcaption>`;
     }
 
-    return `<figure class="figure figure--${layout}"><img src="/images/${image}" loading="lazy" alt="${alt}" />${captionMarkup}</figure>`;
+    const imageMarkup = `<img src="/images/${image}" loading="lazy" alt="${alt}" ${width ? `width="${width}"` : ''} ${height ? `height="${height}"`: ''} />`;
+
+    return `<figure class="figure figure--${layout}">${imageMarkup}${captionMarkup}</figure>`;
   };
 
   eleventyConfig.addShortcode('figureInset', (...args) => figure(args, { layout: 'inset' }));

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,8 +22,6 @@ module.exports = function(eleventyConfig) {
 
     const [width, height] = (size || '').split('x');
 
-    console.log(width, height);
-
     if (caption) {
       const linkMarkup = link ? ` <a class="figure__link" href="${link}" target="_blank" rel="noopener">${label}</a>` : '';
       captionMarkup = `<figcaption class="figure__caption">${caption}${linkMarkup}</figcaption>`;

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,67 +1,19 @@
 const sass = require('node-sass');
-const markdownIt = require("markdown-it");
-const markdownItAnchor = require('markdown-it-anchor');
 const htmlmin = require('html-minifier');
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 
 const { input, output } = require('./config/constants.js');
 const scssConfig = require('./config/scss.js');
-
-const slugify = string => {
-  if (!string) return string;
-
-  const a = `àáäâèéëêìíïîòóöôùúüûñçßÿœæŕśńṕẃǵǹḿǘẍźḧ·/_,:;άαβγδεέζήηθιίϊΐκλμνξοόπρσςτυϋύΰφχψωώ`;
-  const b = `aaaaeeeeiiiioooouuuuncsyoarsnpwgnmuxzh------aavgdeeziitiiiiklmnxooprsstyyyyfhpoo`;
-  const p = new RegExp(a.split(``).join(`|`), `g`);
-
-  return string.toString().trim().toLowerCase()
-    .replace(/ου/g, `ou`)
-    .replace(/ευ/g, `eu`)
-    .replace(/θ/g, `th`)
-    .replace(/ψ/g, `ps`)
-    .replace(/\//g, `-`)
-    .replace(/\s+/g, `-`)          // Replace spaces with -
-    .replace(p, c => b.charAt(a.indexOf(c))) // Replace special chars
-    .replace(/&/g, `and`)          // Replace & with `and`
-    .replace(/[^\w-]+/g, ``)       // Remove all non-word chars
-    .replace(/--+/g, `-`)          // Replace multiple - with single -
-    .replace(/^-+/, ``)            // Trim - from start of text
-    .replace(/-+$/, ``);           // Trim - from end of text
-};
+const markdownConfig = require('./config/markdown.js');
 
 module.exports = function(eleventyConfig) {
   // Libraries
-  const markdownLibrary = markdownIt({
-    html: true,
-    breaks: true,
-    linkify: true
-  }).use(markdownItAnchor, {
-    slugify,
-    // slugify: (s) => {
-    //   const string = String(s)
-    //     .trim()
-    //     .toLowerCase()
-    //     .replace(/\s+/g, '-')
-    //     .replace(/\./g, '');
-
-    //   return encodeURIComponent(string);
-    // },
-    permalink: true,
-    permalinkClass: 'post-article__anchor',
-    permalinkHref: slug => `#${slug}`,
-    permalinkSymbol: "\u00B6",
-  });
-  eleventyConfig.setLibrary('md', markdownLibrary);
+  eleventyConfig.setLibrary('md', markdownConfig);
 
   // Plugins
   eleventyConfig.addPlugin(pluginRss);
 
   // Shortcodes
-  eleventyConfig.addPairedShortcode('markdown', (content) => {
-    const md = new markdownIt({ html: true });
-
-    return md.render(content);
-  });
   eleventyConfig.addPairedShortcode('smallCaps', (content) => `<span class="sc">${content}</span>`);
   const figure = ([ image, alt, caption, link, label ], args = {}) => {
     const { layout } = args;

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,7 @@
 ### How has this been tested?
 
 
+### Is the Lighthouse score affected by this PR?
+
+
 :rocket:

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -48,7 +48,7 @@ const markdownLibrary = markdownIt({
     permalink: true,
     permalinkClass: 'post-article__anchor',
     permalinkHref: slug => `#${slug}`,
-    permalinkSymbol: '\u00B6',
+    permalinkSymbol: '\u00B6', // Pilcrow (¶)
   })
   .use(markdownItAbbr)
   .use(markdownItClass, {

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -1,0 +1,65 @@
+const markdownIt = require("markdown-it");
+const markdownItAnchor = require('markdown-it-anchor');
+const markdownItClass = require('@toycode/markdown-it-class');
+const markdownItAbbr = require('markdown-it-abbr');
+const hljs = require('highlight.js');
+
+const slugify = string => {
+  if (!string) return string;
+
+  const a = `àáäâèéëêìíïîòóöôùúüûñçßÿœæŕśńṕẃǵǹḿǘẍźḧ·/_,:;άαβγδεέζήηθιίϊΐκλμνξοόπρσςτυϋύΰφχψωώ`;
+  const b = `aaaaeeeeiiiioooouuuuncsyoarsnpwgnmuxzh------aavgdeeziitiiiiklmnxooprsstyyyyfhpoo`;
+  const p = new RegExp(a.split(``).join(`|`), `g`);
+
+  return string.toString().trim().toLowerCase()
+    .replace(/ου/g, `ou`)
+    .replace(/ευ/g, `eu`)
+    .replace(/θ/g, `th`)
+    .replace(/ψ/g, `ps`)
+    .replace(/\//g, `-`)
+    .replace(/\s+/g, `-`)          // Replace spaces with -
+    .replace(p, c => b.charAt(a.indexOf(c))) // Replace special chars
+    .replace(/&/g, `and`)          // Replace & with `and`
+    .replace(/[^\w-]+/g, ``)       // Remove all non-word chars
+    .replace(/--+/g, `-`)          // Replace multiple - with single -
+    .replace(/^-+/, ``)            // Trim - from start of text
+    .replace(/-+$/, ``);           // Trim - from end of text
+};
+
+const LANG_NAMES = {
+  js: 'JavaScript',
+  css: 'CSS',
+  html: 'HTML',
+  scss: 'Sass',
+};
+
+const markdownLibrary = markdownIt({
+  html: true,
+  breaks: true,
+  linkify: true,
+  highlight(str, lang) {
+    const codeStr = (lang && hljs.getLanguage(lang) && hljs.highlight(lang, str, true).value) || markdownLibrary.utils.escapeHtml(str);
+
+    return `<pre class="code-block"${lang ? ` data-lang=${LANG_NAMES[lang] || lang}` : ''}><code>${codeStr}</code></pre>`;
+  },
+})
+  .use(markdownItAnchor, {
+    slugify,
+    permalink: true,
+    permalinkClass: 'post-article__anchor',
+    permalinkHref: slug => `#${slug}`,
+    permalinkSymbol: '\u00B6',
+  })
+  .use(markdownItAbbr)
+  .use(markdownItClass, {
+    h1: 'h1',
+    h2: 'h2',
+    h3: 'h3',
+    ul: 'list',
+    ol: 'list list--ordered',
+    blockquote: 'blockquote',
+    cite: 'blockquote__cite',
+    pre: 'pre',
+  });
+
+module.exports = markdownLibrary;

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@toycode/markdown-it-class": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@toycode/markdown-it-class/-/markdown-it-class-1.2.4.tgz",
+      "integrity": "sha512-hA4gHBK8moObkOYdWTjhy1wYcYy0MJeM3JjSKbsXHRpRMvIKhk6Jm+t3bXsSScTdz/byWqQbs8YIwVYjHp+SlQ==",
+      "dev": true
+    },
     "@types/babel-types": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
@@ -2427,6 +2433,12 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz",
+      "integrity": "sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg==",
+      "dev": true
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -3272,6 +3284,12 @@
           "dev": true
         }
       }
+    },
+    "markdown-it-abbr": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-it-abbr/-/markdown-it-abbr-1.0.4.tgz",
+      "integrity": "sha1-1mtTZFIcuz3Yqlna37ovtoZcj9g=",
+      "dev": true
     },
     "markdown-it-anchor": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,14 @@
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",
     "@11ty/eleventy-plugin-rss": "^1.0.7",
-    "markdown-it": "^10.0.0",
-    "markdown-it-anchor": "^5.3.0",
-    "node-sass": "^4.13.1",
+    "@toycode/markdown-it-class": "^1.2.4",
     "eleventy-plugin-reading-time": "0.0.1",
-    "html-minifier": "^4.0.0"
+    "highlight.js": "^10.1.1",
+    "html-minifier": "^4.0.0",
+    "markdown-it": "^10.0.0",
+    "markdown-it-abbr": "^1.0.4",
+    "markdown-it-anchor": "^5.3.0",
+    "node-sass": "^4.13.1"
   },
   "dependencies": {}
 }

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -62,6 +62,30 @@
       #}{{ css | inlineScss | safe }}
     {%- endif %}</style>
 
+    <noscript>
+      <style>
+        body {
+          opacity: 1;
+          visibility: visible;
+        }
+
+        .nav {
+          position: relative;
+          transform: none;
+        }
+
+        .nav-list {
+          /*animation: opacity 250ms 500ms ease-in both;*/
+          transform: none !important;
+        }
+
+        .nav-toggle,
+        .footer .fieldset {
+          display: none;
+        }
+      </style>
+    </noscript>
+
     <!--<script defer src="https://unpkg.com/web-vitals@0.2.2/dist/web-vitals.es5.umd.min.js"></script>
     <script>
       addEventListener('DOMContentLoaded', function() {
@@ -143,6 +167,22 @@
 
         contrastPreferenceSelect.value = contrastPreference;
         setPreference('contrast', contrastPreference);
+
+        var highlightEl = function() {
+          var element = document.getElementById(location.hash.replace('#', ''));
+
+          element.classList.add('js--highlight-anchor');
+
+          setTimeout(() => {
+            element.classList.remove('js--highlight-anchor');
+          }, 3000);
+        }
+
+        if (location.hash) {
+          highlightEl();
+        }
+
+        window.addEventListener('hashchange', highlightEl, false);
       })();
     </script>
   </body>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -55,36 +55,15 @@
     {% for webfont in webfonts %}<link rel="preload" href="/fonts/{{ webfont }}.woff2" as="font" type="font/woff2" crossorigin>
     {% endfor %}
 
-    {% set css %}{% include "styles.scss" %}{% endset %}
-    <style>{{ css | inlineScss | safe }}
+    {% set stylesScss %}{% include "styles.scss" %}{% endset %}
+    <style>{{ stylesScss | inlineScss | safe }}
     {%- if custom_css %}
-      {%- set css %}{% include custom_css %}{% endset %}{#
-      #}{{ css | inlineScss | safe }}
+      {%- set customScss %}{% include custom_css %}{% endset %}{#
+      #}{{ customScss | inlineScss | safe }}
     {%- endif %}</style>
 
-    <noscript>
-      <style>
-        body {
-          opacity: 1;
-          visibility: visible;
-        }
-
-        .nav {
-          position: relative;
-          transform: none;
-        }
-
-        .nav-list {
-          /*animation: opacity 250ms 500ms ease-in both;*/
-          transform: none !important;
-        }
-
-        .nav-toggle,
-        .footer .fieldset {
-          display: none;
-        }
-      </style>
-    </noscript>
+    {% set noscriptScss %}{% include "noscript.scss" %}{% endset %}
+    <noscript><style>{{ noscriptScss | inlineScss | safe }}</style></noscript>
 
     <!--<script defer src="https://unpkg.com/web-vitals@0.2.2/dist/web-vitals.es5.umd.min.js"></script>
     <script>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -16,6 +16,8 @@
 
 {% from "components/hero.html" import hero %}
 
+<link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500&display=swap" rel="stylesheet">
+
 {% set children = "" %}
 {% set children %}
   <p class="post-description"><strong>{{ page.date | formatDate }}</strong>{% if description %} {{ description | safe }}{% endif %}</p>

--- a/src/_includes/noscript.scss
+++ b/src/_includes/noscript.scss
@@ -1,0 +1,20 @@
+body {
+  opacity: 1;
+  visibility: visible;
+}
+
+.nav {
+  position: relative;
+}
+
+.nav-list {
+  &,
+  a::after {
+    transform: none !important;
+  }
+}
+
+.nav-toggle,
+.footer .fieldset {
+  display: none;
+}

--- a/src/_includes/pages/post.scss
+++ b/src/_includes/pages/post.scss
@@ -31,11 +31,7 @@
   }
 
   > p:first-child {
-    @extend %lead;
-
-    a {
-      @extend %lead-a;
-    }
+    @include lead;
   }
 
   .h1, .h2, .h3 {
@@ -80,7 +76,7 @@
     &__caption {
 
       &::before {
-        @extend %lead;
+        @include lead(false);
 
         content: 'Fig. ' counter(section) " ";
         margin-right: 0.1em;

--- a/src/_includes/pages/post.scss
+++ b/src/_includes/pages/post.scss
@@ -44,13 +44,6 @@
     text-decoration-color: var(--c-bC-33);
   }
 
-  a {
-
-    abbr {
-      text-decoration: none; // Prevents a strange double line from being rendered
-    }
-  }
-
   .figure {
     counter-increment: section;
     clear: both;

--- a/src/_includes/pages/post.scss
+++ b/src/_includes/pages/post.scss
@@ -26,18 +26,6 @@
     line-height: 1;
   }
 
-  h1 {
-    @extend %h1;
-  }
-
-  h2 {
-    @extend %h2;
-  }
-
-  h3 {
-    @extend %h3;
-  }
-
   > :first-child {
     margin-top: 0;
   }
@@ -50,41 +38,17 @@
     }
   }
 
-  code {
-    color: var(--c-bA);
-    font-size: 1.1em;
-    font-weight: 600;
+  abbr {
+    text-decoration: underline dotted;
+    text-underline-position: under;
+    text-decoration-color: var(--c-bC-33);
   }
 
   a {
 
-    code {
-      color: inherit;
-      text-decoration-color: inherit;
+    abbr {
+      text-decoration: none; // Prevents a strange double line from being rendered
     }
-  }
-
-  pre {
-    background: var(--c-hB);
-    clear: both;
-    padding: 1.8em 2em 2em;
-    font-size: 1rem;
-    line-height: 1.66;
-    white-space: pre-wrap;
-    margin: 2rem 0;
-    max-width: 48em;
-
-    @include min-width(768) {
-      font-size: 1.125rem;
-    }
-
-    code {
-      font-size: 1em;
-    }
-  }
-
-  blockquote {
-    @extend %blockquote;
   }
 
   .figure {

--- a/src/_includes/pages/post.scss
+++ b/src/_includes/pages/post.scss
@@ -38,6 +38,10 @@
     }
   }
 
+  .h1, .h2, .h3 {
+    display: table;
+  }
+
   abbr {
     text-decoration: underline dotted;
     text-underline-position: under;

--- a/src/_includes/scss/_base.scss
+++ b/src/_includes/scss/_base.scss
@@ -7,38 +7,43 @@ html, body {
 
 @mixin dark-colors {
   --c-hB: #110E14; // Header BG
+  --c-hA: #F75C6A; // Header Accent
 
   --c-bB: #{lighten(#19161C, 1%)}; // Body BG
   --c-bC: #EEE7E7; // Body Color
   --c-bC-66: #{rgba(#EEE7E7, 0.66)}; // Body Color (66%)
   --c-bC-33: #{rgba(#EEE7E7, 0.33)}; // Body Color (33%)
   --c-bA: #f75c6a; // Body Accent
+  --c-bH: #{rgba(mix(white, yellow, 50%), 0.25)}; // Body Highlight
 
   --figO: 0.9; // Figure Opacity
 
   --c-cB: #000; // Contrast BG
   --c-cC: #FFF; // Contrast Color
   --c-cC-50: #{rgba(#FFF, 0.5)};
-  --c-cA: #FBCDD1; // Contrast Accent
+  --c-cA: #{lighten(#f75c6a, 10%)}; // Contrast Accent
 }
 
 @mixin light-colors {
   --c-hB: #FCFBFB;
+  --c-hA: #EA3243;
 
-  --c-bB: #EEE7E7;
+  --c-bB: #{lighten(#EEE7E7, 4%)};
   --c-bC: #19161C;
   --c-bC-66: #{rgba(#19161C, 0.66)};
   --c-bC-33: #{rgba(#19161C, 0.33)};
-  --c-bA: #{darken(#EA3243, 5%)};
+  --c-bA: #{darken(#EA3243, 8%)};
+  --c-bH: rgba(yellow, 0.25); // Body Highlight
 
   --c-cB: #FFF;
   --c-cC: #000;
   --c-cC-50: #{rgba(#000, 0.5)};
-  --c-cA: #6C000A;
+  --c-cA: #{darken(#EA3243, 20%)};
 }
 
 @mixin contrast-colors {
   --c-hB: var(--c-cB);
+  --c-hA: var(--c-cA);
 
   --c-bB: var(--c-cB);
   --c-bC: var(--c-cC);
@@ -139,8 +144,9 @@ a,
   border: 0;
 
   code {
-    text-decoration: inherit;
-    text-decoration-color: currentColor;
+    color: inherit;
+    font-weight: inherit;
+    text-decoration: none;
   }
 
   &:hover,
@@ -185,5 +191,15 @@ a,
 
   .link--pseudo:active & {
     opacity: 0.66;
+  }
+}
+
+.js--highlight-anchor {
+  animation: fade-highlight 2s 1s ease-out both;
+
+  @keyframes fade-highlight {
+    from {
+      background-color: var(--c-bH);
+    }
   }
 }

--- a/src/_includes/scss/_base.scss
+++ b/src/_includes/scss/_base.scss
@@ -8,7 +8,7 @@ html, body {
 @mixin dark-colors {
   --c-hB: #110E14; // Header BG
 
-  --c-bB: #19161C; // Body BG
+  --c-bB: #{lighten(#19161C, 1%)}; // Body BG
   --c-bC: #EEE7E7; // Body Color
   --c-bC-66: #{rgba(#EEE7E7, 0.66)}; // Body Color (66%)
   --c-bC-33: #{rgba(#EEE7E7, 0.33)}; // Body Color (33%)

--- a/src/_includes/scss/_base.scss
+++ b/src/_includes/scss/_base.scss
@@ -149,6 +149,10 @@ a,
     text-decoration: none;
   }
 
+  abbr {
+    text-decoration: none; // Prevents a strange double line from being rendered
+  }
+
   &:hover,
   &:focus {
     color: var(--c-bA);

--- a/src/_includes/scss/_figure.scss
+++ b/src/_includes/scss/_figure.scss
@@ -15,7 +15,7 @@
 
   &__caption {
     background: var(--c-hB);
-    padding: 0.25em 0.667em 0.6em;
+    padding: 0.25em 0.667em 0.5em;
     font-size: 0.825rem;
     display: table-caption;
     caption-side: bottom;

--- a/src/_includes/scss/_hero.scss
+++ b/src/_includes/scss/_hero.scss
@@ -42,24 +42,23 @@
     padding-right: 8rem;
     box-sizing: border-box;
 
-    @media(hover: hover) and (pointer: fine) {
+    @media (hover: hover) and (pointer: fine) {
       padding-right: 4rem
     }
 
     > span {
-      opacity: 0;
-      transition: opacity 400ms 250ms ease-out;
+      animation: opacity 400ms 250ms ease-out both;
+      color: var(--c-bC);
+    }
 
-      .fonts-loaded & {
-        opacity: 1;
-        color: var(--c-bC);
-      }
+    a:not(:hover):not(:focus) {
+      text-decoration-color: var(--c-bC-33);
     }
 
     &::before {
       animation: scale-from-left 500ms 125ms ease-out both;
       content: '\2013\2013\2013\2013';
-      color: var(--c-bA);
+      color: var(--c-hA);
       letter-spacing: -0.2em;
       margin-right: 0.5em;
       width: 1.75em;
@@ -75,6 +74,7 @@
 
   .h1 {
     animation: opacity 800ms 100ms ease-out both;
+    color: var(--c-hA);
     margin-bottom: 0.25em;
   }
 }

--- a/src/_includes/scss/_list.scss
+++ b/src/_includes/scss/_list.scss
@@ -55,14 +55,3 @@
 .list--ordered {
   @extend %ordered-list;
 }
-
-.typeset {
-
-  ul {
-    @extend %list;
-  }
-
-  ol {
-    @extend %ordered-list;
-  }
-}

--- a/src/_includes/scss/_nav.scss
+++ b/src/_includes/scss/_nav.scss
@@ -1,4 +1,4 @@
-$nav-height: 3rem;
+$nav-height: 2.5rem;
 
 .nav {
   position: fixed;
@@ -10,12 +10,15 @@ $nav-height: 3rem;
   text-align: right;
   display: flex;
   flex-direction: column;
-  transform: translateY(#{$nav-height * -1});
 
   .js--menu & {
 
     .nav-list {
-      transform: translateY(#{$nav-height});
+
+      &,
+      a::after {
+        transform: none;
+      }
     }
   }
 
@@ -25,7 +28,11 @@ $nav-height: 3rem;
     &:focus-within {
 
       .nav-list {
-        transform: translateY(#{$nav-height});
+
+        &,
+        a::after {
+          transform: none;
+        }
       }
     }
   }
@@ -131,6 +138,7 @@ $nav-height: 3rem;
   display: inline-block;
   pointer-events: auto;
   padding: 1.25em 0.25em 0.75em;
+  margin-bottom: -0.75em;
   text-decoration: none;
   transition: 250ms ease-in-out;
   transition-property: opacity, transform;
@@ -197,8 +205,9 @@ $nav-height: 3rem;
 }
 
 .nav-list {
-  background: var(--c-bC);
-  color: var(--c-bB);
+  background: var(--c-hB);
+  border-bottom: 2px solid var(--c-bB);
+  color: var(--c-bC);
   margin: 0;
   position: relative;
   z-index: 2;
@@ -207,10 +216,13 @@ $nav-height: 3rem;
   font-size: 1rem;
   padding: 0;
   height: $nav-height;
+  margin-bottom: $nav-height * -1;
   display: flex;
   transition: transform 250ms ease-in-out;
+  transform: translateY(#{$nav-height * -1});
 
   &::after {
+    opacity: 0.25;
     content: '';
     width: 100%;
     height: 1.5rem;
@@ -229,17 +241,41 @@ $nav-height: 3rem;
   }
 
   li {
-    margin-left: -0.5rem;
+    margin-left: 0;
     margin-right: 1rem;
   }
 
   a {
-    display: block;
-    padding: 0 0.5rem 0.25em;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    padding: 0 0 0.25em;
+    height: $nav-height;
+    position: relative;
+    text-decoration: none;
+
+    &::after {
+      content: '';
+      border-radius: 1px;
+      position: absolute;
+      bottom: -2px;
+      height: 2px;
+      background: var(--c-bC);
+      opacity: 0.33;
+      width: 100%;
+      left: 0;
+      transition: 125ms ease-in-out;
+      transition-property: background, opacity, transform;
+      transform: translateY(-2px);
+    }
 
     &:hover,
     &:focus {
       color: currentColor;
+
+      &::after {
+        opacity: 1;
+      }
     }
 
     &:focus {
@@ -247,15 +283,22 @@ $nav-height: 3rem;
     }
 
     &.active {
-      background: var(--c-bA);
-      color: var(--c-bB);
+      color: var(--c-hA);
       text-decoration: none;
       transition-property: color, background, opacity;
 
+      &::after {
+        background: var(--c-hA);
+        opacity: 1;
+      }
+
       &:hover,
       &:focus {
-        background: var(--c-bB);
         color: var(--c-bC);
+
+        &::after {
+          background: currentColor;
+        }
       }
     }
   }

--- a/src/_includes/scss/_nav.scss
+++ b/src/_includes/scss/_nav.scss
@@ -42,7 +42,6 @@ $nav-height: 2.5rem;
   animation: nav 800ms 500ms ease-out both;
   display: flex;
   justify-content: flex-end;
-  order: 9;
   position: relative;
   z-index: 10;
 
@@ -148,7 +147,8 @@ $nav-height: 2.5rem;
   transform: translateY(-0.25em);
   width: 2.25em;
   text-align: center;
-  position: relative;
+  position: absolute;
+  right: 0;
 
   &::before,
   &::after {
@@ -216,7 +216,6 @@ $nav-height: 2.5rem;
   font-size: 1rem;
   padding: 0;
   height: $nav-height;
-  margin-bottom: $nav-height * -1;
   display: flex;
   transition: transform 250ms ease-in-out;
   transform: translateY(#{$nav-height * -1});

--- a/src/_includes/scss/_reset.scss
+++ b/src/_includes/scss/_reset.scss
@@ -10,11 +10,6 @@ dt {
   margin: 0;
 }
 
-abbr {
-  text-decoration: none;
-  border-bottom: 0;
-}
-
 strong {
   font-weight: 500;
 }

--- a/src/_includes/scss/_type.scss
+++ b/src/_includes/scss/_type.scss
@@ -16,7 +16,6 @@
 %h1 {
   @extend %heading-large;
 
-  color: var(--c-bA);
   max-width: 16em;
   margin: calc(0.25em + 1vw) 0 calc(0.25em + 2vw);
   font-size: 5.5vw;

--- a/src/_includes/scss/_type.scss
+++ b/src/_includes/scss/_type.scss
@@ -40,53 +40,6 @@
   scroll-margin-top: 1.25em;
 }
 
-%blockquote {
-  font-family: 'rsa-heading', serif;
-  font-weight: 400;
-  font-style: italic;
-  font-size: clamp(1.5rem, calc(1rem + 1vw), 2.5rem);
-  margin: 2em 0;
-  line-height: 1.3;
-  max-width: 24em;
-
-  cite {
-    @extend %lead;
-
-    font-size: 1.25rem;
-    font-family: 'rsa-body', sans-serif;
-    font-style: normal;
-    margin-top: 0.25em;
-    display: block;
-
-    a {
-      @extend %lead-a;
-    }
-  }
-
-  &::before {
-    content: '“';
-    color: var(--c-bA);
-    display: block;
-    font-weight: 600;
-    font-style: normal;
-    width: 0.5em;
-    left: 0;
-    top: 0.05em;
-    font-size: 1.5em;
-    position: relative;
-    line-height: 0.5;
-  }
-
-  > p {
-    position: relative;
-    margin-bottom: 0.5em;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-}
-
 %lead {
   @include sc;
 

--- a/src/_includes/scss/_type.scss
+++ b/src/_includes/scss/_type.scss
@@ -39,18 +39,20 @@
   scroll-margin-top: 1.25em;
 }
 
-%lead {
+@mixin lead($link: true) {
   @include sc;
 
   color: var(--c-bA);
   font-weight: 500;
-}
 
-%lead-a {
-  text-decoration-color: currentColor;
+  @if ($link) {
+    a {
+      text-decoration-color: currentColor;
 
-  &:hover,
-  &:focus {
-    color: var(--c-bC);
+      &:hover,
+      &:focus {
+        color: var(--c-bC);
+      }
+    }
   }
 }

--- a/src/_includes/scss/_typography.scss
+++ b/src/_includes/scss/_typography.scss
@@ -43,7 +43,7 @@ del {
   max-width: 24em;
 
   cite {
-    @extend %lead;
+    @include lead;
 
     font-size: 1.25rem;
     font-family: 'rsa-body', sans-serif;
@@ -53,10 +53,6 @@ del {
 
     &::before {
       content: '— ';
-    }
-
-    a {
-      @extend %lead-a;
     }
   }
 
@@ -129,9 +125,5 @@ code {
 }
 
 .lead {
-  @extend %lead;
-
-  a {
-    @extend %lead-a;
-  }
+  @include lead;
 }

--- a/src/_includes/scss/_typography.scss
+++ b/src/_includes/scss/_typography.scss
@@ -12,7 +12,7 @@ p,
 }
 
 del {
-  text-decoration-color: var(--c-bA);
+  text-decoration-color: var(--c-bC-66);
   text-decoration-thickness: 2px;
 }
 
@@ -33,7 +33,106 @@ del {
 }
 
 .blockquote {
-  @extend %blockquote;
+  font-family: 'rsa-heading', serif;
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.5rem, calc(1rem + 1vw), 2.5rem);
+  margin: 2em 0;
+  line-height: 1.3;
+  max-width: 24em;
+
+  cite {
+    @extend %lead;
+
+    font-size: 1.25rem;
+    font-family: 'rsa-body', sans-serif;
+    font-style: normal;
+    margin-top: 0.25em;
+    display: block;
+
+    &::before {
+      content: '— ';
+    }
+
+    a {
+      @extend %lead-a;
+    }
+  }
+
+  &::before {
+    content: '“';
+    color: var(--c-bA);
+    display: block;
+    font-weight: 600;
+    font-style: normal;
+    width: 0.5em;
+    left: 0;
+    top: 0.05em;
+    font-size: 1.5em;
+    position: relative;
+    line-height: 0.5;
+  }
+
+  > p {
+    position: relative;
+    margin-bottom: 0.5em;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+abbr {
+  border-bottom: 0;
+  text-decoration: none;
+}
+
+code {
+  color: var(--c-bA);
+  font-weight: 400;
+  font-size: 0.85em;
+  font-family: 'Fira Mono', monospace;
+
+  a & {
+    color: inherit;
+    font-weight: 500;
+  }
+}
+
+.code-block {
+  background: var(--c-hB);
+  clear: both;
+  padding: 1.8em 2em 2em;
+  font-size: 1rem;
+  white-space: pre-wrap;
+  margin: 2rem 0;
+  max-width: 48em;
+
+  &[data-lang] {
+    position: relative;
+
+    &::before {
+      @extend .sc;
+
+      content: attr(data-lang);
+      color: var(--c-bC-66);
+      font-family: 'rsa-body', sans-serif;
+      position: absolute;
+      top: 0;
+      right: 0.5em;
+      font-weight: 500;
+      font-size: 0.75rem;
+    }
+  }
+
+  code {
+    line-height: 1.85;
+  }
+}
+
+.hljs-comment {
+  opacity: 0.66;
 }
 
 .lead {

--- a/src/_includes/scss/_typography.scss
+++ b/src/_includes/scss/_typography.scss
@@ -12,7 +12,8 @@ p,
 }
 
 del {
-  text-decoration-color: var(--c-bC-66);
+  color: var(--c-bC-66);
+  text-decoration-color: var(--c-bC);
   text-decoration-thickness: 2px;
 }
 
@@ -93,21 +94,17 @@ code {
   font-weight: 400;
   font-size: 0.85em;
   font-family: 'Fira Mono', monospace;
-
-  a & {
-    color: inherit;
-    font-weight: 500;
-  }
 }
 
 .code-block {
   background: var(--c-hB);
   clear: both;
-  padding: 1.8em 2em 2em;
-  font-size: 1rem;
+  padding: 1.8em 2em 1.6em;
+  font-size: 0.9375rem;
+  line-height: 1.85;
   white-space: pre-wrap;
   margin: 2rem 0;
-  max-width: 48em;
+  max-width: 52em;
 
   &[data-lang] {
     position: relative;
@@ -119,20 +116,16 @@ code {
       color: var(--c-bC-66);
       font-family: 'rsa-body', sans-serif;
       position: absolute;
-      top: 0;
-      right: 0.5em;
+      top: -0.25em;
+      right: 0.334em;
       font-weight: 500;
       font-size: 0.75rem;
     }
   }
-
-  code {
-    line-height: 1.85;
-  }
 }
 
 .hljs-comment {
-  opacity: 0.66;
+  color: var(--c-bC-66);
 }
 
 .lead {

--- a/src/curriculum-vitae.njk
+++ b/src/curriculum-vitae.njk
@@ -52,10 +52,10 @@ custom_css: pages/cv.scss
       <p>Since joining – and with particular focus in the last few years – I have led the development on all things <a href="https://fueled.com">fueled.com</a>. In 2018 we tore everything down and set about building a component library in line with the new brand direction. Part of the challenge was convincing stakeholders of behind-the-scenes changes for a more stable code base including publishing it as a private <span class="sc">NPM</span> package for better consumption across multiple&nbsp;repositories.</p>
 
       <ul class="list">
-        <li><time class="lead" datetime="2019-01">2019–present</time> Lead Frontend Engineer</li>
-        <li><time class="lead" datetime="2017-01">2017–19</time> Senior Frontend Developer</li>
-        <li><time class="lead" datetime="2015-06">2015–17</time> Frontend Developer</li>
-        <li><time class="lead" datetime="2014-07">2014–15</time> Web Designer</li>
+        <li><time class="lead" datetime="2019-01">2019–present</time>&ensp;Lead Frontend Engineer</li>
+        <li><time class="lead" datetime="2017-01">2017–19</time>&ensp;Senior Frontend Developer</li>
+        <li><time class="lead" datetime="2015-06">2015–17</time>&ensp;Frontend Developer</li>
+        <li><time class="lead" datetime="2014-07">2014–15</time>&ensp;Web Designer</li>
       </ul>
 
       <h3 class="h3">University of Reading</h3>
@@ -64,7 +64,7 @@ custom_css: pages/cv.scss
       <p>With a bit of project scope creep, I ended up being the sole designer and developer associated with a complete redesign and redevelopment of the main university pages concerned with attracting prospective students and improving current student&nbsp;experience.</p>
 
       <ul class="list">
-        <li><time class="lead" datetime="2013-06P365D">2013–14</time> Digital Designer</li>
+        <li><time class="lead" datetime="2013-06P365D">2013–14</time>&ensp;Digital Designer</li>
       </ul>
 
       <h3 class="h3">Freelance design and development</h3>
@@ -72,11 +72,11 @@ custom_css: pages/cv.scss
       <p><span class="lead">While at university and since,</span> I have taken on select freelance projects to finance my bike obsession! I’ve built agency web presences for <strong>Kickpush</strong>, rebranded sports personalities like <strong>Hotspur Related</strong>, and for a while ran a successful channel on YouTube centered around designing brand identities for famous content creators like&nbsp;KSI. There are also fun side projects – like my dad’s pizza recipe birthday microsite and a <span class="sc">LEGO</span> naming pointer – in the list&nbsp;below:</p>
 
       <ul class="list">
-        <li><time class="lead" datetime="2019-01">2019</time> <a href="https://ourdadmakes.pizza">Our dad makes pizza</a></li>
-        <li><time class="lead" datetime="2016P730D">2016–18</time> <a href="https://kickpush.co">Kickpush</a></li>
-        <li><time class="lead" datetime="2016">2016</time> <a href="https://www.unifie.com/">Unifie</a></li>
-        <li><time class="lead" datetime="2014">2014</time> <a href="http://www.lodge192.com/">Lion &amp; Lamb Lodge</a>, Hotspur Related, <a href="http://legonotlegos.com"><span class="sc">LEGO</span> not Legos</a></li>
-        <li><time class="lead" datetime="2013-09">2013</time> <a href="/journal/2013/responsive-web-design-techniques">Responsive web design techniques</a> course for Envato Tuts+</li>
+        <li><time class="lead" datetime="2019-01">2019</time>&ensp;<a href="https://ourdadmakes.pizza">Our dad makes pizza</a></li>
+        <li><time class="lead" datetime="2016P730D">2016–18</time>&ensp;<a href="https://kickpush.co">Kickpush</a></li>
+        <li><time class="lead" datetime="2016">2016</time>&ensp;<a href="https://www.unifie.com/">Unifie</a></li>
+        <li><time class="lead" datetime="2014">2014</time>&ensp;<a href="http://www.lodge192.com/">Lion &amp; Lamb Lodge</a>, Hotspur Related, <a href="http://legonotlegos.com"><span class="sc">LEGO</span> not Legos</a></li>
+        <li><time class="lead" datetime="2013-09">2013</time>&ensp;<a href="/journal/2013/responsive-web-design-techniques">Responsive web design techniques</a> course for Envato Tuts+</li>
       </ul>
     </div>
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -16,17 +16,17 @@ custom_css: pages/home.scss
 
 <main class="main home-content">
   <div class="home-content__wrapper group">
-    <div class="home-content__section--work" id="work">
-      <p class="p"><span class="lead">By day I am a Lead Frontend Engineer at <a href="https://fueled.com/team/rob-sterlini" target="_blank" rel="noopener">Fueled</a>.</span> In&nbsp;the nearly six years I have been at Fueled, I have led the development on projects for <strong>Apple</strong>, crafted digital experiences for global personalities like <strong>Tony Robbins</strong>, and developed innovative web presences for fledgling start-ups like <strong>Keetoo</strong>, and&nbsp;<strong>Omstars</strong>.</p>
+    <div class="home-content__section--work">
+      <p class="p"><span class="lead" id="work">By day I am a Lead Frontend Engineer at <a href="https://fueled.com/team/rob-sterlini" target="_blank" rel="noopener">Fueled</a>.</span> In&nbsp;the nearly six years I have been at Fueled, I have led the development on projects for <strong>Apple</strong>, crafted digital experiences for global personalities like <strong>Tony Robbins</strong>, and developed innovative web presences for fledgling start-ups like <strong>Keetoo</strong>, and&nbsp;<strong>Omstars</strong>.</p>
       <p>In 2018, I began spearheading the rebuild of <a href="https://fueled.com"><strong>fueled.com</strong></a> underpinned by an extensible, consistent Vue.js component library that aligned with a brand refresh within the&nbsp;organisation.</p>
     </div>
-    <div class="home-content__section--life" id="life">
-      <p><span class="lead">Away from the screen I like swimming, cycling, and running&hellip;</span> occasionally one after the other. I&apos;ve been participating in triathlon since 2015 and have <a href="https://www.instagram.com/p/BZJncXEAQgv/" target="_blank" rel="noopener">one <abbr title="Ironman 70.3" class="sc">IM&nbsp;70.3</abbr></a> under my belt with my sights firmly set on a full Ironman in&nbsp;2021.</p>
+    <div class="home-content__section--life">
+      <p><span class="lead" id="life">Away from the screen I like swimming, cycling, and running&hellip;</span> occasionally one after the other. I&apos;ve been participating in triathlon since 2015 and have <a href="https://www.instagram.com/p/BZJncXEAQgv/" target="_blank" rel="noopener">one <abbr title="Ironman 70.3" class="sc">IM&nbsp;70.3</abbr></a> under my belt with my sights firmly set on a full Ironman in&nbsp;2021.</p>
       <p>I&apos;m pretty into <span class="sc">LEGO</span> – you might have heard me banging the <a href="http://legonotlegos.com" target="_blank" rel="noopener"><span class="sc">LEGO</span>&nbsp;not&nbsp;Legos</a> drum on Twitter, where you&apos;d also find me tweeting about my beloved&nbsp;Spurs.</p>
       <p>When the season is right I love outdoor activities like skiing, hiking, and recently <a href="https://www.instagram.com/p/B7_0MLWn_ii/" target="_blank" rel="noopener">scuba&nbsp;diving!</a></p>
     </div>
-    <div class="home-content__section--contact" id="contact">
-      <p><span class="lead">Wanna say hi?</span> Email&nbsp;me at <a href="mailto:hi@robsterlini.co.uk">hi@robsterlini.co.uk</a> or tweet me at&nbsp;<a href="https://twitter.com/robsterlini" target="_blank" rel="noopener">@robsterlini</a>.</p>
+    <div class="home-content__section--contact">
+      <p><span class="lead" id="contact">Wanna say hi?</span> Email&nbsp;me at <a href="mailto:hi@robsterlini.co.uk">hi@robsterlini.co.uk</a> or tweet me at&nbsp;<a href="https://twitter.com/robsterlini" target="_blank" rel="noopener">@robsterlini</a>.</p>
       <p>You can find my photos on <a href="https://instagram.com/robsterlini" target="_blank" rel="noopener">Instagram</a>, code on <a href="https://github.com/robsterlini" target="_blank" rel="noopener">Github</a>, activities on <a href="https://www.strava.com/athletes/6578573" target="_blank" rel="noopener">Strava</a>, experiments on <a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Codepen</a>, my job history on <a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">LinkedIn</a>, and <a href="/curriculum-vitae">my&nbsp;<abbr title="Curriculum vitae" class="sc">CV</abbr></a>.</p>
 
       {#<p>You can <a href="/">check out my&nbsp;<abbr title="Curriculum vitae" class="sc">CV</abbr></a>. Elsewhere on the internet you can find&nbsp;my:</p>

--- a/src/journal.njk
+++ b/src/journal.njk
@@ -48,7 +48,7 @@ custom_css: pages/journal.scss
         {% if loop.last %}
             </ul>
 
-            <p>Follow the <a href="/feed.xml"><span class="sc">RSS</span> feed</a> for updates.</p>
+            <p>Follow the <a href="/feed.xml"><span class="sc">RSS</span> feed</a> for&nbsp;updates.</p>
           </div>
         {% endif %}
     {% endfor %}

--- a/src/journal/2014/opentype-and-selection-dont-mix.md
+++ b/src/journal/2014/opentype-and-selection-dont-mix.md
@@ -1,5 +1,5 @@
 ---
-title: Opentype and ::selection don’t mix
+title: Opentype and ::selection don’t mix
 date: 2014-04-29
 description: Fixing the dubious way that Chrome on <abbr title="Mac OS X" class="sc">OSX</abbr> borks OpenType features when used with a custom ::selection.
 layout: post
@@ -26,6 +26,7 @@ Here’s the <span class="sc">CSS</span> that will recreate the problem:
   color: #fff;
   text-shadow: none;
 }
+
 p {
   font-family: "ff-tisa-web-pro", "Tisa Pro", "Tisa", "Cambo", serif;
   font-style: normal;
@@ -40,12 +41,14 @@ Which gives you this:
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-1.jpg",
+  "",
   "The OpenType features looking beautiful",
   "The OpenType features looking beautiful"
 %}
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-2.jpg",
+  "",
   "::selection looking not-so-beautiful",
   "::selection looking not-so-beautiful"
 %}
@@ -60,12 +63,14 @@ The easiest solution is to not use a custom `::selection` or to not use the Open
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-3.jpg",
+  "",
   "No OT features…",
   "No OT features…"
 %}
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-4.jpg",
+  "",
   "…but no ::selection problems",
   "…but no ::selection problems"
 %}
@@ -102,6 +107,7 @@ html[data-useragent*='Chrome'][data-platform*='Mac'] p {
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-5.jpg",
+  "",
   "Problem solved?",
   "Problem solved?"
 %}
@@ -110,6 +116,7 @@ But even this has a problem with the `::selection`…
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-6.jpg",
+  "",
   "Nearly, but not quite",
   "Nearly, but not quite"
 %}
@@ -134,12 +141,14 @@ The only caveat is that you need to use a contrasting colour to the text – in 
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-7.jpg",
+  "",
   "Problem solved?",
   "Problem solved?"
 %}
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-8.jpg",
+  "",
   "You betcha!",
   "You betcha!"
 %}

--- a/src/journal/2014/opentype-and-selection-dont-mix.md
+++ b/src/journal/2014/opentype-and-selection-dont-mix.md
@@ -1,10 +1,14 @@
 ---
 title: Opentype and ::selection don’t mix
 date: 2014-04-29
-description: Fixing the dubious way that Chrome on <span class='sc'>OSX</span> borks OpenType features when used with a custom ::selection.
+description: Fixing the dubious way that Chrome on <abbr title="Mac OS X" class="sc">OSX</abbr> borks OpenType features when used with a custom ::selection.
 layout: post
 tags: journal
 ---
+
+*[OSX]: Mac OS X
+*[CSS]: Cascading Stylesheets
+*[OT]: OpenType
 
 ## The problem
 
@@ -14,20 +18,23 @@ I’m a type-snob/type-nerd. I want to use the beautiful OpenType features on of
 
 It does do the OpenType bit really well, but if you’re using a custom `::selection` to add an extra level of detail then you’ll start to have problems!
 
-Here’s the <span class="sc">CSS</span> that will recreate the problem
+Here’s the <span class="sc">CSS</span> that will recreate the problem:
 
-    ::selection {
-      background: #ff4444;
-      color: #fff;
-      text-shadow: none;
-    }
-    p {
-      font-family: "ff-tisa-web-pro", "Tisa Pro", "Tisa", "Cambo", serif;
-      font-style: normal;
-      font-weight: 400;
-      -webkit-font-smoothing: antialiased;
-      -webkit-font-feature-settings: "kern", "liga", "case", "onum"; /* I‘ve left out the other prefixes as this is a Chrome-only issue */
-    }
+```css
+::selection {
+  background: #ff4444;
+  color: #fff;
+  text-shadow: none;
+}
+p {
+  font-family: "ff-tisa-web-pro", "Tisa Pro", "Tisa", "Cambo", serif;
+  font-style: normal;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  /* I’ve left out the other prefixes as this is a Chrome-only issue */
+  -webkit-font-feature-settings: "kern", "liga", "case", "onum";
+}
+```
 
 Which gives you this:
 
@@ -69,23 +76,29 @@ Before switching over to using the `font-feature-settings` that I now use (havin
 
 It is however a solution to the problem.
 
-    p {
-      -webkit-font-feature-settings: normal;
-      text-rendering: optimizeLegibility;
-    }
+```css
+p {
+  -webkit-font-feature-settings: normal;
+  text-rendering: optimizeLegibility;
+}
+```
 
 It would also mean sacrificing the tasty features on all the other browsers, but *A List Apart* had a similar issue and solved it with [a bit of JS browser-sniffing](https://github.com/alistapart/AListApart/issues/53 "Find out how A List Apart fixed it"):
 
-    var b = document.documentElement;
-    b.setAttribute('data-useragent',  navigator.userAgent);
-    b.setAttribute('data-platform', navigator.platform);
+```js
+var b = document.documentElement;
+b.setAttribute('data-useragent',  navigator.userAgent);
+b.setAttribute('data-platform', navigator.platform);
+```
 
 …and then only applying the <span class="sc">CSS</span> to those that are using Chrome on <span class="sc">OSX</span>:
 
-    html[data-useragent*='Chrome'][data-platform*='Mac'] p {
-      -webkit-font-feature-settings: normal;
-      text-rendering: optimizeLegibility;
-    }
+```css
+html[data-useragent*='Chrome'][data-platform*='Mac'] p {
+  -webkit-font-feature-settings: normal;
+  text-rendering: optimizeLegibility;
+}
+```
 
 {% figureFull
   "journal/opentype-and-selection-dont-mix/ot-5.jpg",
@@ -107,11 +120,13 @@ And even then it still doesn’t deliver what I want.
 
 But from there I thought that instead of sacrificing ranging numbers, I’d sacrifice a level of the custom `::selection` instead.
 
-    html[data-useragent*='Chrome'][data-platform*='Mac'] ::selection {
-      background: #d1d4d9;
-      color: inherit;
-      text-shadow: inherit;
-    }
+```css
+html[data-useragent*='Chrome'][data-platform*='Mac'] ::selection {
+  background: #d1d4d9;
+  color: inherit;
+  text-shadow: inherit;
+}
+```
 
 I worked out that it was the `colour` and `text-shadow`, but not the `background` that was breaking it, so remove them from the equation and there we have it: custom `::selection` with the beauty of the OT features.
 

--- a/src/journal/2014/three-months-at-fueled.md
+++ b/src/journal/2014/three-months-at-fueled.md
@@ -1,5 +1,5 @@
 ---
-title: My first three months at Fueled
+title: My first three months at Fueled
 date: 2014-10-06
 layout: post
 tags: journal

--- a/src/journal/2015/triathlete.md
+++ b/src/journal/2015/triathlete.md
@@ -1,5 +1,5 @@
 ---
-title: I’m a triathlete
+title: I’m a triathlete
 date: 2015-07-14
 edited: 2015-11-01
 description: 12 July saw me tackle two turbo triathlons in a bid to experience a new sport, and I fell bike over cleat in love with it!
@@ -21,6 +21,7 @@ Triathlon was perfect.
 
 {% figureInset
   "journal/triathlete/reservoir.jpg",
+  "",
   "A snap of me on on a sunny day at the reservoir",
   "Swimming in a reservoir is made easier by the Huub Archimedes wetsuit!",
   "https://instagram.com/p/3lTk5Gv-4L/",
@@ -49,6 +50,7 @@ My first triathlon.
 
 {% figureInset
   "journal/triathlete/bike-racked.jpg",
+  "",
   "A photo of my bike, hanging on the rack",
   "Chrissy just hanging out before the big event."
 %}
@@ -81,6 +83,7 @@ We’d not anticipated the amount of rain that had come down already, and it was
 
 {% figureInset
   "journal/triathlete/scraped-side.jpg",
+  "",
   "A photo of my scraped side after the fall",
   "No race is complete without war wounds, right?",
   "https://instagram.com/p/5CD89iv-03/",
@@ -101,6 +104,7 @@ I’d be lying if I said there weren’t any tears.
 
 {% figureInset
   "journal/triathlete/the-run.jpg",
+  "",
   "A photo of me exiting T2 and into the run",
   "Leg day, all day!",
   "https://instagram.com/p/5CkZiTv-1s/",
@@ -131,6 +135,7 @@ The tears of pain from the first time round came back again, but as those ‘can
 
 {% figureFull
   "journal/triathlete/finish-line.jpg",
+  "",
   "A photo of me at the finish line",
   "Pushing myself over the line in the morning’s final leg"
 %}
@@ -153,6 +158,7 @@ Overall, it was just sensational.
 
 {% figureInset
   "journal/triathlete/super-mum.jpg",
+  "",
   "A quick selfie with my mum before the triathlons got under way",
   "Couldn’t have done it without her, and the unwavering support from the rest of the famiglia Sterlini!"
 %}
@@ -169,6 +175,7 @@ Onto the next one!
 
 {% figureFull
   "journal/triathlete/champion.jpg",
+  "",
   "A photo of me with my bike above my head, and my medal in my hand!",
   "An obligatory bike-above-head, medal photo before heading home with all the DOMs",
   "https://instagram.com/p/5Cofm6v--t/",

--- a/src/journal/2016/parkrun-changed-my-life.md
+++ b/src/journal/2016/parkrun-changed-my-life.md
@@ -1,5 +1,5 @@
 ---
-title: Parkrun changed my life
+title: Parkrun changed my life
 date: 2016-08-03
 description: "The last two years have been a blur of running and self realisation, but simply put: my life has changed."
 layout: post
@@ -16,6 +16,7 @@ There are a few topless photos on the way, so apologies in advance if you’re i
 
 {% figureInset
   "journal/parkrun-changed-my-life/april-2014.jpg",
+  "",
   "A snap of me in April 2014",
   "A very sad looking starting photo in early April 2014"
 %}
@@ -50,6 +51,7 @@ When I moved to South London over a year ago now, I was in prime location for ru
 
 {% figureInset
   "journal/parkrun-changed-my-life/rpf.jpg",
+  "",
   "A photo of my mum and me before the start of the RPF Half Marathon",
   "This wonder-woman of a mum and I cruised personal bests at the RPF Half in October 2015"
 %}
@@ -86,6 +88,7 @@ It was so special.
 
 {% figureFull
   "journal/parkrun-changed-my-life/startline.jpg",
+  "",
   "A selfie of my mum and me getting set to take on the Brighton Marathon",
   "Running late for the start, but always time for a start-line selfie with this superstar!",
   "https://www.instagram.com/p/BEV_jVrv-10/",
@@ -96,6 +99,7 @@ Now obviously I couldn’t let her cross the finish line without any cheering (s
 
 {% figureInset
   "journal/parkrun-changed-my-life/medal.jpg",
+  "",
   "A photo from the Tuesday after my marathon, where Charlie presented me with my medal",
   "Every crew needs a captain, and running under Charlie’s banner has changed my life",
   "https://www.instagram.com/p/BEZdnBPP-z2/",
@@ -124,6 +128,7 @@ It’s been a while now since I ran that race, but I’ve not quite found the ri
 
 {% figureInset
   "journal/parkrun-changed-my-life/progress.jpg",
+  "",
   "A photo from 2014, and a photo from now",
   "It’s been a long way to here, and we’re not done&nbsp;yet"
 %}
@@ -150,6 +155,7 @@ Oh, and the idea of an Ironman is very much something that I want to have a go a
 
 {% figureFull
   "journal/parkrun-changed-my-life/jbtt.jpg",
+  "",
   "Three photos of my swim, bike, and run at Jenson Button Trust Triathlon",
   "What a day that was!",
   "https://www.instagram.com/p/BEZdnBPP-z2/",

--- a/src/journal/2016/parkrun-changed-my-life.md
+++ b/src/journal/2016/parkrun-changed-my-life.md
@@ -1,7 +1,7 @@
 ---
 title: Parkrun changed my life
 date: 2016-08-03
-description: The last two years have been a blur of running and self realisation, but simply put. My life has changed.
+description: "The last two years have been a blur of running and self realisation, but simply put: my life has changed."
 layout: post
 tags: journal
 ---

--- a/src/journal/2020/a-fresh-lick-of-paint.md
+++ b/src/journal/2020/a-fresh-lick-of-paint.md
@@ -1,7 +1,7 @@
 ---
-title: A fresh lick of paint
+title: A fresh lick of paint
 date: 2020-06-11
-description: Quarantine gave me back a bunch of commuting time; I put mine towards yoga and Eleventy… you are viewing the result!
+description: Quarantine gave me back a bunch of commuting time; I put mine towards yoga and Eleventy… you are viewing the result!
 layout: post
 tags: journal
 ---
@@ -22,6 +22,7 @@ The problem I've faced in the past is getting ahead of myself and trying to solv
 
 {% figureInset
   "journal/a-new-start/sketch.png",
+  "1514x815",
   "A screenshot of the work-in-progress design in Sketch",
   "You can probably see which aspects were kept from this&nbsp;design."
 %}
@@ -40,6 +41,7 @@ With a rough design down, and some potential typefaces chosen this would be the 
 
 {% figureInset
   "journal/a-new-start/v0.png",
+  "1571x1067",
   "A screenshot of the work-in-progress build deployed on Netlify Drop",
   "I cannot stress how straightforward it is to get a site live on Netlify, either with the drag and drop of files, or with an actual build pipeline."
 %}
@@ -56,6 +58,7 @@ There is no way to change from build pipeline to the drag and drop on Netlify fo
 
 {% figureInset
   "journal/a-new-start/netlify-vanilla.png",
+  "419x428",
   "A partial screenshot of my production settings in Netlify",
   "Creating an automated deployment of static sites was a breeze!"
 %}


### PR DESCRIPTION
### What does this PR change?
Separates out the Markdown config into its own file to more easily add functionality for the journal posts:
* Uses [@toycode/markdown-it-class](https://www.npmjs.com/package/@toycode/markdown-it-class) to add classes to the markdown removing the need for `.post-article > .h1` _etc_ duplicating declarations on the post pages
* Basic syntax highlighting including more consistent code representation with webfonts (this needs to be tested to check the Lighthouse impact)

### Does it fix any (other) issues?
* Fixes the colour accessibility concerns – closes https://github.com/robsterlini/robsterlini-frontend/issues/14
* Fixes the lack of image size functionality for figures (but doesn't implement them all on old posts) – closes https://github.com/robsterlini/robsterlini-frontend/issues/15
* Updates design for global navigation
* Adds hash highlighting (potential blog post #16)
* Added a number of non-breaking spaces to prevent orphans
* Adds an extra question to the PR template to ensure that the Lighthouse scores remain unaffected

### Are there any backend requirements or frontend dependencies?
A number of new packages have been installed (mostly Markdown It plugins)

### How has this been tested?
Locally and on Netlify

### Is the Lighthouse score affected by this PR?
The homepage stays at 4 by 💯

:rocket:
