### PR TITLE
Add journal pagination

### DIFF
--- a/config/filters/formatDate.js
+++ b/config/filters/formatDate.js
@@ -1,0 +1,11 @@
+const formatDate = date => {
+  const options = {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  };
+
+  return new Intl.DateTimeFormat('en-GB', options).format(date);
+};
+
+module.exports = formatDate;

--- a/config/filters/generateSocialImage.js
+++ b/config/filters/generateSocialImage.js
@@ -1,0 +1,47 @@
+const generateSocialImage = ({ header, title }) => {
+  const cloudinaryEncode = (text = '') => {
+    const unencodedText = `${text}`
+      .replace(/&amp;/g, '%26')
+      .replace(/\,/g, '%2C');
+
+    return encodeURIComponent(unencodedText);
+  };
+
+  const imageProps = [
+    'w_1440',
+    'h_720',
+    'q_100',
+  ];
+
+  const headerProps = [
+    'w_800',
+    'h_86',
+    'c_fit',
+    'y_160',
+    'x_195',
+    'g_north_west',
+    'co_rgb:EEE7E7',
+    `l_text:rs-b-600.otf_56_bold_left_:${cloudinaryEncode(header)}`,
+  ];
+
+  const titleProps = [
+    'w_1200',
+    'h_420',
+    'y_280',
+    'x_110',
+    'c_fit',
+    'g_north_west',
+    'co_rgb:F75C6A',
+    `l_text:rs-h-700.otf_90_bold_left_line_spacing_20_:${cloudinaryEncode(title)}`,
+  ];
+
+  return [
+    'https://res.cloudinary.com/dym2d96h6/image/upload',
+    imageProps.join(','),
+    headerProps.join(','),
+    titleProps.join(','),
+    'v1592751314/robsterlini/meta.png',
+  ].join('/');
+};
+
+module.exports = generateSocialImage;

--- a/config/journal.js
+++ b/config/journal.js
@@ -1,0 +1,41 @@
+const getJournalLink = (entry, eleventyConfig) =>  {
+  if (!entry) return {};
+
+  let domain, htmlAttrs;
+
+  let {
+    url,
+    data: { title },
+  } = entry;
+
+  const { external_url } = entry.data;
+
+  title = `Read ‘${title || 'the entry'}’`;
+
+  if (!external_url) {
+    url = eleventyConfig.getFilter('url')(url);
+  }
+
+  else {
+    url = external_url;
+    domain = url.match(/^(?:https?:)?(?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n]+)/)[1];
+    title += ` on ${domain}`;
+  }
+
+  htmlAttrs = `href="${url}" title="${title}"`;
+
+  if (domain) {
+    htmlAttrs += ' target="_blank" rel="noopener"';
+  }
+
+  return {
+    domain,
+    url,
+    title,
+    htmlAttrs,
+  };
+};
+
+module.exports = {
+  getJournalLink,
+};

--- a/config/shortcodes/figure.js
+++ b/config/shortcodes/figure.js
@@ -1,0 +1,17 @@
+const figure = ([ image, size, alt, caption, link, label ], args = {}) => {
+  const { layout } = args;
+  let captionMarkup = '';
+
+  const [width, height] = (size || '').split('x');
+
+  if (caption) {
+    const linkMarkup = link ? ` <a class="figure__link" href="${link}" target="_blank" rel="noopener">${label}</a>` : '';
+    captionMarkup = `<figcaption class="figure__caption">${caption}${linkMarkup}</figcaption>`;
+  }
+
+  const imageMarkup = `<img src="/images/${image}" loading="lazy" alt="${alt}" ${width ? `width="${width}"` : ''} ${height ? `height="${height}"`: ''} />`;
+
+  return `<figure class="figure figure--${layout}">${imageMarkup}${captionMarkup}</figure>`;
+};
+
+module.exports = figure;

--- a/config/shortcodes/journal.js
+++ b/config/shortcodes/journal.js
@@ -1,0 +1,52 @@
+const formatDateFilter = require('./../filters/formatDate.js');
+
+const journalEntry = (entry, titleTag, lead) => {
+  if (!entry) return '';
+
+  const {
+    data: {
+      title,
+      description,
+    } = {},
+    date,
+    link,
+  } = entry;
+
+  const titleMarkup = lead ?
+    `<${titleTag}>
+      <span class="p lead">${lead}</span>
+      <span class="${titleTag}">${title}</span>
+    </${titleTag}>` :
+    `<${titleTag} class="${titleTag}">${title}</${titleTag}>`;
+
+  const descriptionMarkup = `<p><strong>${formatDateFilter(date)}</strong>${description ? ` ${description}` : ``}</p>`;
+
+  const linkMarkup = `<p class="list__item">
+    <a class="journal-first link--pseudo" ${link.htmlAttrs}>
+      <span class="link__pseudo">Read the entry${link.domain ? ` on ${link.domain}` : ``}</span>${link.domain ? `<span class="accent">&#8239;&#8599;</span>` : ``}
+    </a>
+  </p>`
+
+  return `${titleMarkup}${descriptionMarkup}${linkMarkup}`;
+};
+
+const journalEntryShort = (entry) => {
+  if (!entry) return '';
+  const {
+    data: {
+      title,
+    },
+    date,
+    link,
+  } = entry;
+
+  return `<a class="link--pseudo" ${link.htmlAttrs}>
+    <span class="link__pseudo">${title}</span>${link.domain ? '<span class="accent">&#8239;&#8599;</span>' : ''}
+    <span class="regular nowrap">${formatDateFilter(date)}</span>
+  </a>`;
+};
+
+module.exports = {
+  journalEntry,
+  journalEntryShort,
+};

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,7 +1,7 @@
 <footer class="footer">
   <div class="group footer__wrapper">
     <p>
-      <a href="https://robsterlini.co.uk">robsterlini.co.uk</a> is built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a>, hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify</a>, with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/tree/2020-11ty-vanilla" target="_blank" rel="noopener">GitHub</a>. Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta</a>, and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
+      <a href="https://robsterlini.co.uk">robsterlini.co.uk</a> is built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a>, hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify</a>, with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/" target="_blank" rel="noopener">GitHub</a>. Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta</a>, and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
     </p>
 
     <div class="fieldset">

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -31,20 +31,12 @@
 {% set isOldPost %}{{ page.date | isOldDate }}{% endset %}
 
 <main class="main">
-  {% set post_data = {
-    url: url,
-    data: {
-      external_url: external_url,
-      title: title
-    }
-  } %}
-  {% set entry_link = post_data | getJournalLink %}
-  {% if external_url %}
+  {% if entry.link.domain %}
   <article class="group">
     <p>
       <span class="lead">Originally posted</span><br>
       <span class="list__item">
-        <a {{ entry_link.htmlAttrs | safe }}>{{ entry_link.domain }}</a>
+        <a {{ entry.link.htmlAttrs | safe }}>{{ entry.link.domain }}</a>
       </span>
     </p>
   </article>
@@ -52,5 +44,31 @@
   <article class="group post-article">
     {{ content | safe }}
   </article>
+
+  <div class="post-pagination group">
+    {% set previousEntry = collections.internalEntries | reverse | getPreviousCollectionItem(page) %}
+    {% set nextEntry = collections.internalEntries | reverse | getNextCollectionItem(page) %}
+
+    <h2 class="h2">What now?</h2>
+
+    <div class="post-pagination__page">
+      <h3 class="p lead">Share it!</h3>
+      {% set twitterShareText %}{{ title }} by – @robsterlini{% endset %}
+      <p>If you enjoyed this post, and think others would benefit from reading it then feel free to <a href="http://twitter.com/share?text={{ twitterShareText | urlencode }}&url={{ page.url | url | absoluteUrl(global.url) | urlencode }}" target="_blank" rel="noopener" title="Share this entry on Twitter">share it on Twitter</a> (or elsewhere). I’m always up for a discussion about anything I’ve written too, so <a href="/#contact">get in touch</a> if you want to&nbsp;chat!</p>
+    </div>
+
+    {% for paginatedKey, paginatedEntry in { next: nextEntry, prev: previousEntry } %}
+      <div class="post-pagination__page{% if not paginatedEntry %} post-pagination__page--current{% endif %}">
+        {% if paginatedEntry %}
+          {% set paginatedLead = "Later entry" if paginatedKey == "next" else "Earlier entry" %}
+          {% set entry = paginatedEntry %}
+        {% else %}
+          {% set paginatedLead = "Latest entry" if paginatedKey == "next" else "First entry" %}
+          {% set entry = collections.internalEntries | getCollectionItem(page) %}
+        {% endif %}
+        {% journalEntry entry, "h3", paginatedLead %}
+      </div>
+    {% endfor %}
+  </div>
   {% endif %}
 </main>

--- a/src/_includes/pages/journal.scss
+++ b/src/_includes/pages/journal.scss
@@ -16,26 +16,6 @@
   }
 }
 
-.journal-latest {
-
-  .h2 {
-    margin-top: 0.25em;
-  }
-
-  &__date {
-    font-weight: 500;
-  }
-}
-
-.journal-older {
-
-  &__date {
-    font-weight: 300;
-    text-decoration: none;
-    white-space: nowrap;
-  }
-
-  &__external {
-    color: var(--c-bA);
-  }
+.journal-entry-short__date {
+  // white-space: nowrap;
 }

--- a/src/_includes/pages/post.scss
+++ b/src/_includes/pages/post.scss
@@ -77,3 +77,38 @@
     }
   }
 }
+
+.post-pagination {
+  display: grid;
+  grid-gap: 0 2rem;
+
+  .h2 {
+    grid-column: 1 / -1;
+    margin-top: 3em;
+  }
+
+  &__page {
+    margin-bottom: 1.5rem; // TOOD: Var single gutter
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+
+    &--current {
+      color: var(--c-bC-33);
+
+      // Hides the link for current articles
+      .list__item {
+        display: none;
+      }
+    }
+  }
+
+  @include min-width(1024) {
+    grid-template-columns: 5fr 3fr 3fr;
+
+    &__page {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/src/_includes/scss/_base.scss
+++ b/src/_includes/scss/_base.scss
@@ -207,3 +207,7 @@ a,
     }
   }
 }
+
+.accent {
+  color: var(--c-bA);
+}

--- a/src/_includes/scss/_nav.scss
+++ b/src/_includes/scss/_nav.scss
@@ -22,7 +22,7 @@ $nav-height: 2.5rem;
     }
   }
 
-  @media(hover: hover) and (pointer: fine) {
+  @media (hover: hover) and (pointer: fine) {
 
     &:hover,
     &:focus-within {
@@ -86,6 +86,12 @@ $nav-height: 2.5rem;
   align-items: center;
   margin: 0.6rem;
   order: -1;
+  position: absolute;
+  right: 0;
+
+  .nav-logo + & {
+    right: 3.5rem;
+  }
 
   &:focus {
     border-color: var(--c-bC);

--- a/src/_includes/scss/_reset.scss
+++ b/src/_includes/scss/_reset.scss
@@ -5,13 +5,12 @@ figure,
 blockquote,
 dl,
 dd,
-dt {
+dt,
+h1,
+h2,
+h3 {
   padding: 0;
   margin: 0;
-}
-
-strong {
-  font-weight: 500;
 }
 
 fieldset {

--- a/src/_includes/scss/_type.scss
+++ b/src/_includes/scss/_type.scss
@@ -32,6 +32,7 @@
 }
 
 %h3 {
+  display: block;
   font-weight: 500;
   font-size: 1.4rem;
   margin-top: 1.25em;

--- a/src/_includes/scss/_typography.scss
+++ b/src/_includes/scss/_typography.scss
@@ -33,6 +33,19 @@ del {
   @extend %h3;
 }
 
+.regular {
+  font-weight: 300;
+}
+
+.strong,
+strong {
+  font-weight: 500;
+}
+
+.nowrap {
+  white-space: nowrap;
+}
+
 .blockquote {
   font-family: 'rsa-heading', serif;
   font-weight: 400;
@@ -126,4 +139,9 @@ code {
 
 .lead {
   @include lead;
+
+  + .h2,
+  + .h3 {
+    margin-top: 0.25em;
+  }
 }

--- a/src/_redirects.njk
+++ b/src/_redirects.njk
@@ -36,8 +36,7 @@ https://robsterlini-frontend.netlify.com/* https://robsterlini.co.uk/:splat 301!
 /journal{{ oldPath }}   /journal{{ newPath }}   301
 {%- endfor %}
 
-{%- set entries = collections | getJournalEntries %}
-{%- for entry in entries %}
+{%- for entry in collections.entries %}
   {%- if entry.data.external_url %}
 {{ entry.url | url }} {{ entry.data.external_url }} 301
   {%- endif %}

--- a/src/index.njk
+++ b/src/index.njk
@@ -37,7 +37,7 @@ custom_css: pages/home.scss
         <li><a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Experiments on Codepen</a></li>
         <li><a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">History on LinkedIn</a></li>
       </ul>#}
-      {% set entry = collections | getFirstJournalEntry %}
+      {% set entry = collections.entries[0] %}
       <p><span class="lead">Read the latest journal entry:</span> <a href="{{ entry.data.external_url if entry.data.external_url else entry.url | url }}">{{ entry.data.title }}</a>, posted on {{ entry.date | formatDate }}; or peruse <a href="/journal/">the&nbsp;archive</a>.</p>
     </div>
   </div>

--- a/src/journal.njk
+++ b/src/journal.njk
@@ -15,42 +15,28 @@ tag: journal
 <main class="main journal">
   <div class="group">
     {% for entry in collections.entries %}
-      {% set entry_link = entry | getJournalLink %}
-        {% if loop.index == 1 %}
-          <div class="journal-latest">
-            <h2 class="p">
-              <span class="lead">Latest entry</span>
-              <span class="h2">{{ entry.data.title }}</span>
-            </h2>
-            <p><span class="journal-latest__date">{{ entry.date | formatDate }}</span>{% if entry.data.description %} {{ entry.data.description }}{% endif %}</p>
-            <p class="list__item">
-              <a class="journal-first link--pseudo" {{ entry_link.htmlAttrs | safe }}>
-                <span class="link__pseudo">Read the entry{% if entry_link.domain %} on {{ entry_link.domain }}</span><span class="journal-older__external">&#8239;&#8599;</span>{% endif %}
-              </a>
-            </p>
-          </div>
+      {% if loop.index == 1 %}
+        <div>
+          {% journalEntry entry, "h2", "Latest entry" %}
+        </div>
 
-          <div class="journal-older">
-            <h2 class="p"><span class="lead">Older entries</span></h2>
-            <ul class="list">
-        {% endif %}
+        <div class="journal-older">
+          <h2 class="p"><span class="lead">Older entries</span></h2>
+          <ul class="list">
+      {% endif %}
 
-        {% if loop.index > 1 %}
-              <li>
-                <a class="journal-older__link link--pseudo" {{ entry_link.htmlAttrs | safe }}>
-                  <span class="journal-older__label link__pseudo">{{ entry.data.title }}</span>
-                  {%- if entry_link.domain %}<span class="journal-older__external">&#8239;&#8599;</span>{% endif %}
-                  <span class="journal-older__date">{{ entry.date | formatDate }}</span>
-                </a>
-              </li>
-        {% endif %}
+      {% if loop.index > 1 %}
+            <li>
+              {% journalEntryShort entry %}
+            </li>
+      {% endif %}
 
-        {% if loop.last %}
-            </ul>
+      {% if loop.last %}
+          </ul>
 
-            <p>Follow the <a href="/feed.xml"><span class="sc">RSS</span> feed</a> for&nbsp;updates.</p>
-          </div>
-        {% endif %}
+          <p>Follow the <a href="/feed.xml"><span class="sc">RSS</span> feed</a> for&nbsp;updates.</p>
+        </div>
+      {% endif %}
     {% endfor %}
   </div>
 </main>

--- a/src/journal.njk
+++ b/src/journal.njk
@@ -5,6 +5,7 @@ layout: default
 sitemap_priority: 0.8
 nav: journal
 custom_css: pages/journal.scss
+tag: journal
 ---
 
 {% from "components/hero.html" import hero %}
@@ -13,8 +14,7 @@ custom_css: pages/journal.scss
 
 <main class="main journal">
   <div class="group">
-    {% set entries = collections | getJournalEntries %}
-    {% for entry in entries %}
+    {% for entry in collections.entries %}
       {% set entry_link = entry | getJournalLink %}
         {% if loop.index == 1 %}
           <div class="journal-latest">

--- a/src/journal/2013/responsive-web-design-techniques.md
+++ b/src/journal/2013/responsive-web-design-techniques.md
@@ -2,6 +2,5 @@
 title: Responsive web design techniques
 date: 2013-09-30
 layout: post
-tags: journal
 external_url: https://webdesign.tutsplus.com/courses/responsive-web-design-techniques
 ---

--- a/src/journal/2014/opentype-and-selection-dont-mix.md
+++ b/src/journal/2014/opentype-and-selection-dont-mix.md
@@ -3,7 +3,6 @@ title: Opentype and ::selection don’t mix
 date: 2014-04-29
 description: Fixing the dubious way that Chrome on <abbr title="Mac OS X" class="sc">OSX</abbr> borks OpenType features when used with a custom ::selection.
 layout: post
-tags: journal
 ---
 
 *[OSX]: Mac OS X

--- a/src/journal/2015/triathlete.md
+++ b/src/journal/2015/triathlete.md
@@ -4,7 +4,6 @@ date: 2015-07-14
 edited: 2015-11-01
 description: 12 July saw me tackle two turbo triathlons in a bid to experience a new sport, and I fell bike over cleat in love with it!
 layout: post
-tags: journal
 ---
 
 ## Why triathlon?

--- a/src/journal/2016/parkrun-changed-my-life.md
+++ b/src/journal/2016/parkrun-changed-my-life.md
@@ -1,9 +1,8 @@
 ---
 title: Parkrun changed my life
 date: 2016-08-03
-description: "The last two years have been a blur of running and self realisation, but simply put: my life has changed."
+description: "The last two years have been a blur of running and self realisation, but simply put: my life has changed."
 layout: post
-tags: journal
 ---
 
 This post has been a long time coming.

--- a/src/journal/2020/a-fresh-lick-of-paint.md
+++ b/src/journal/2020/a-fresh-lick-of-paint.md
@@ -3,7 +3,6 @@ title: A fresh lick of paint
 date: 2020-06-11
 description: Quarantine gave me back a bunch of commuting time; I put mine towards yoga and Eleventy… you are viewing the result!
 layout: post
-tags: journal
 ---
 
 ‘Painting the Forth Bridge’.


### PR DESCRIPTION
### What does this PR change?
Refactors the configuration files for the journal (and a few other filters to be a little tidier), and adds [previous and next pagination](https://www.11ty.dev/docs/filters/collection-items/) for journal entries

### Does it fix any (other) issues?
* Adds a few helper classes for reusable quick styling
* Fixes the nav on touch devices

### Are there any backend requirements or frontend dependencies?
No

### How has this been tested?
Locally

### Is the Lighthouse score affected by this PR?
[Nope! 💯](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Frobsterlini.co.uk%2Fjournal%2F2020%2Fa-fresh-lick-of-paint%2F)

:rocket:
