### PR TITLE
Add external link icon 🔗

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ It’s okay for it to be improved iteratively… there will always be more to do
 * Separate items with a spaced en-dash, represent durations or ranges with an unspaced en-dash, join words with a hyphen
 * Use correct micro-typographic glyphs – `&times;` not x _etc_
 * Use non-breaking spaces – either `&nbsp;`, `\xa0`, or ` ` (<kbd>⇧</kbd>–<kbd>⌥</kbd>–<kbd>Space</kbd>) – between the final two words of anything that might split over two lines to avoid typographic orphans
+* Immediate punctuation (full stops, commas, colons _etc_) lives inside links (as discussed on [Twitter](https://twitter.com/robsterlini/status/1290545839748898821))
 
 ## Setup
 

--- a/config/markdown.js
+++ b/config/markdown.js
@@ -2,6 +2,8 @@ const markdownIt = require("markdown-it");
 const markdownItAnchor = require('markdown-it-anchor');
 const markdownItClass = require('@toycode/markdown-it-class');
 const markdownItAbbr = require('markdown-it-abbr');
+const mila = require('markdown-it-link-attributes')
+
 const hljs = require('highlight.js');
 
 const slugify = string => {
@@ -49,6 +51,13 @@ const markdownLibrary = markdownIt({
     permalinkClass: 'anchor',
     permalinkHref: slug => `#${slug}`,
     permalinkSymbol: '\u00B6', // Pilcrow (¶)
+  })
+  .use(mila, {
+    pattern: /^https:/,
+    attrs: {
+      target: '_blank',
+      rel: 'noopener'
+    }
   })
   .use(markdownItAbbr)
   .use(markdownItClass, {

--- a/config/shortcodes/journal.js
+++ b/config/shortcodes/journal.js
@@ -20,11 +20,12 @@ const journalEntry = (entry, titleTag, lead, showLink = true) => {
     </${titleTag}>` :
     `<${titleTag} class="${titleTag}">${title}</${titleTag}>`;
 
-  let tagsMarkup = '';
+  let tagsMarkup;
 
   if (tags.length) {
+    tagsMarkup = ' ';
     tags.forEach((tag, index) => {
-      tagsMarkup += ` ${index > 0 ? ', ' : ''}<a href="/journal/${tag}/">#${tag}</a>`;
+      tagsMarkup += `${index > 0 ? ', ' : ''}<a href="/journal/${tag}/">#${tag}</a>`;
     });
   }
 
@@ -50,7 +51,7 @@ const journalEntryShort = (entry, inline = false) => {
   } = entry;
 
   return `<a class="link--pseudo link--external" ${link.htmlAttrs}>
-    <span class="link__pseudo">${title}</span><span class="regular">${inline ? ', posted on ' : ''}<span class="nowrap${!inline ? ' block' : ''}">${formatDateFilter(date)}</span></span></a>`;
+    <span class="link__pseudo">${title}${inline ? ',' : ''}</span><span class="regular">${inline ? ' posted on ' : ''}<span class="nowrap${!inline ? ' block' : ''}">${formatDateFilter(date)}</span></span></a>`;
 };
 
 module.exports = {

--- a/config/shortcodes/journal.js
+++ b/config/shortcodes/journal.js
@@ -32,7 +32,7 @@ const journalEntry = (entry, titleTag, lead, showLink = true) => {
 
   const linkMarkup = `<p class="list__item">
     <a class="journal-first link--pseudo" ${link.htmlAttrs}>
-      <span class="link__pseudo">Read the entry${link.domain ? ` on ${link.domain}` : ``}</span>${link.domain ? `<span class="accent">&#8239;&#8599;</span>` : ``}
+      <span class="link__pseudo">Read the entry${link.domain ? ` on ${link.domain}` : ``}</span>
     </a>
   </p>`
 
@@ -49,8 +49,8 @@ const journalEntryShort = (entry, inline = false) => {
     link,
   } = entry;
 
-  return `<a class="link--pseudo" ${link.htmlAttrs}>
-    <span class="link__pseudo">${title}</span>${link.domain ? '<span class="accent">&#8239;&#8599;</span>' : ''}<span class="regular">${inline ? ', posted on ' : ''}<span class="nowrap${!inline ? ' block' : ''}">${formatDateFilter(date)}</span></span></a>`;
+  return `<a class="link--pseudo link--external" ${link.htmlAttrs}>
+    <span class="link__pseudo">${title}</span><span class="regular">${inline ? ', posted on ' : ''}<span class="nowrap${!inline ? ' block' : ''}">${formatDateFilter(date)}</span></span></a>`;
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3321,6 +3321,11 @@
       "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
       "dev": true
     },
+    "markdown-it-link-attributes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-link-attributes/-/markdown-it-link-attributes-3.0.0.tgz",
+      "integrity": "sha512-B34ySxVeo6MuEGSPCWyIYryuXINOvngNZL87Mp7YYfKIf6DcD837+lXA8mo6EBbauKsnGz22ZH0zsbOiQRWTNg=="
+    },
     "maximatch": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,7 @@
     "markdown-it-anchor": "^5.3.0",
     "node-sass": "^4.14.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "markdown-it-link-attributes": "^3.0.0"
+  }
 }

--- a/src/_data/now.js
+++ b/src/_data/now.js
@@ -20,15 +20,29 @@ module.exports = () => ({
     '2020': {
       winter: {
         life: '<a href="https://www.instagram.com/p/B7rUI5SnNY7/" target="_blank">celebrating Christmas</a> for the first time in a flat that I own, and <a href="https://www.instagram.com/p/B84WwZpnMXI/" target="_blank">skiing with my family</a> in&nbsp;Andorra.',
-        work: 'leveraging Gatsby and Contentful at Fueled to build a new site for&nbsp;<a href="http://svclnk.com/" target="_blank">ServiceLink</a>.',
+        work: 'leveraging Gatsby and Contentful at Fueled to build a new site for&nbsp;<a href="http://svclnk.com/" target="_blank">ServiceLink.</a>',
+        music: {
+          artist: 'The Rose\xa0Club',
+          link: 'https://open.spotify.com/artist/2e0LY1LL3HNFdDhvojMe2r?si=vMwHh9uvQu2Jrm7ImcZZ9g',
+        },
       },
       spring: {
         life: 'putting my <span class="sc">PADI</span> scuba diving <abbr class="sc" title="open water">OW</abbr> qualification <a href="https://www.instagram.com/p/B7_0MLWn_ii/" target="_blank">into practice</a> in Costa&nbsp;Rica!',
-        work: 'finishing up a new homepage for <a href="https://fueled.com" target="_blank">fueled.com</a>.',
+        work: 'finishing up a new homepage for <a href="https://fueled.com" target="_blank">fueled.com.</a>',
+        music: {
+          artist: 'Kano',
+          title: 'Hoodies All\xa0Summer',
+          link: 'https://open.spotify.com/album/0N6HQ1sWJTf4QJxipeEazS?si=z9uy82NVTSaCTo8V1ccViQ',
+        },
       },
       summer: {
-        life: '<a href="https://www.instagram.com/p/CCRJTgoHzml/" target="_blank">discovering trail running</a>, but sadly not on the start line for Ironman&nbsp;UK amid global race cancellations due to Covid-19.',
-        work: 'building web experiences at Fueled for Tony Robbins’ Robbins Research Institute.',
+        life: '<a href="https://www.instagram.com/p/CCRJTgoHzml/" target="_blank">discovering trail running</a>, but sadly not on the start line for Ironman&nbsp;UK amid global race cancellations due to <span class="sc">Covid</span>-19.',
+        work: 'building web experiences at Fueled for Tony\xa0Robbins’ Robbins Research\xa0Institute.',
+        music: {
+          artist: 'Daði\xa0Freyr',
+          title: 'Think About\xa0Things',
+          link: 'https://www.youtube.com/watch?v=VFZNvj-HfBU',
+        },
       },
     },
   },

--- a/src/_data/now.js
+++ b/src/_data/now.js
@@ -36,7 +36,7 @@ module.exports = () => ({
         },
       },
       summer: {
-        life: '<a href="https://www.instagram.com/p/CCRJTgoHzml/" target="_blank">discovering trail running</a>, but sadly not on the start line for Ironman&nbsp;UK amid global race cancellations due to <span class="sc">Covid</span>-19.',
+        life: '<a href="https://www.instagram.com/p/CCRJTgoHzml/" target="_blank">discovering trail running,</a> but sadly not on the start line for Ironman&nbsp;UK amid global race cancellations due to <span class="sc">Covid</span>-19.',
         work: 'building web experiences at Fueled for Tony\xa0Robbins’ Robbins Research\xa0Institute.',
         music: {
           artist: 'Daði\xa0Freyr',

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,7 +1,7 @@
 <footer class="footer">
   <div class="group footer__wrapper links--external">
     <p>
-      <a href="/">robsterlini.co.uk</a> is built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a>, hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify</a>, with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/" target="_blank" rel="noopener">GitHub</a>. Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta</a>, and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
+      <a href="/">robsterlini.co.uk</a> is built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy,</a> hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify,</a> with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/" target="_blank" rel="noopener">GitHub.</a> Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta,</a> and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
     </p>
 
     <div class="fieldset">

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,7 +1,7 @@
 <footer class="footer">
   <div class="group footer__wrapper">
     <p>
-      <a href="https://robsterlini.co.uk">robsterlini.co.uk</a> is built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a>, hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify</a>, with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/" target="_blank" rel="noopener">GitHub</a>. Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta</a>, and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
+      <a href="/">robsterlini.co.uk</a> is built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a>, hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify</a>, with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/" target="_blank" rel="noopener">GitHub</a>. Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta</a>, and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
     </p>
 
     <div class="fieldset">

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <div class="group footer__wrapper">
+  <div class="group footer__wrapper links--external">
     <p>
       <a href="/">robsterlini.co.uk</a> is built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a>, hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify</a>, with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/" target="_blank" rel="noopener">GitHub</a>. Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta</a>, and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
     </p>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -66,7 +66,7 @@ eleventyComputed:
     <div class="post-pagination__page">
       <h3 class="p lead">Thank you!</h3>
       <p>Firstly, thanks for taking the time to read this&nbsp;entry.</p>
-      <p>If you enjoyed this post, and think others would benefit from reading it then feel free to <a href="http://twitter.com/share?text={{ twitterShareText | urlencode }}&url={{ page.url | url | absoluteUrl(global.url) | urlencode }}" target="_blank" rel="noopener" title="Share this entry on Twitter">share it on Twitter</a> (or elsewhere). I’m always up for a discussion about anything I’ve written too, so <a href="/#contact">get in touch</a> if you want to&nbsp;chat!</p>
+      <p>If you enjoyed this post, and think others would benefit from reading it then feel free to <a href="https://twitter.com/share?text={{ twitterShareText | urlencode }}&url={{ page.url | url | absoluteUrl(global.url) | urlencode }}" target="_blank" rel="noopener" title="Share this entry on Twitter">share it on Twitter</a> (or elsewhere). I’m always up for a discussion about anything I’ve written too, so <a href="/#contact">get in touch</a> if you want to&nbsp;chat!</p>
       <p>If you’ve spotted something out of place or something needs correcting, feel free to open a <abbr title="Pull request" class="sc">PR</abbr> for <a href="{{ githubEntryUrl }}" target="_blank" rel="noopener">this entry</a>, <a href="https://github.com/robsterlini/robsterlini-frontend/issues/new/choose" target="_blank" rel="noopener">raise an issue</a>, or <a href="/#contact">let me know</a>.</p>
     </div>
 

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -27,7 +27,7 @@ eleventyComputed:
 {% set header %}
   {% if entry.data.tags %}
     {% for tag in entry.data.tags %}
-      <a href="/journal/{{ tag }}">#{{ tag }}</a>{% if not loop.last %}, {% endif %}
+      <a href="/journal/{{ tag }}">#{{ tag }}{% if not loop.last %},{% endif %}</a>
     {% endfor %}
   {% else %}
     <a href="/journal/">The journal</a>
@@ -67,7 +67,7 @@ eleventyComputed:
       <h3 class="p lead">Thank you!</h3>
       <p>Firstly, thanks for taking the time to read this&nbsp;entry.</p>
       <p>If you enjoyed this post, and think others would benefit from reading it then feel free to <a href="https://twitter.com/share?text={{ twitterShareText | urlencode }}&url={{ page.url | url | absoluteUrl(global.url) | urlencode }}" target="_blank" rel="noopener" title="Share this entry on Twitter">share it on Twitter</a> (or elsewhere). I’m always up for a discussion about anything I’ve written too, so <a href="/#contact">get in touch</a> if you want to&nbsp;chat!</p>
-      <p>If you’ve spotted something out of place or something needs correcting, feel free to open a <abbr title="Pull request" class="sc">PR</abbr> for <a href="{{ githubEntryUrl }}" target="_blank" rel="noopener">this entry</a>, <a href="https://github.com/robsterlini/robsterlini-frontend/issues/new/choose" target="_blank" rel="noopener">raise an issue</a>, or <a href="/#contact">let me know</a>.</p>
+      <p>If you’ve spotted something out of place or something needs correcting, feel free to open a <abbr title="Pull request" class="sc">PR</abbr> for <a href="{{ githubEntryUrl }}" target="_blank" rel="noopener">this entry,</a> <a href="https://github.com/robsterlini/robsterlini-frontend/issues/new/choose" target="_blank" rel="noopener">raise an issue,</a> or <a href="/#contact">let me&nbsp;know.</a></p>
     </div>
 
     {% for paginatedKey, paginatedEntry in { next: nextEntry, prev: previousEntry } %}

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -48,7 +48,7 @@ eleventyComputed:
     </p>
   </article>
   {% else %}
-  <article class="group group--thin post-article">
+  <article class="group group--thin post-article links--external">
     {{ content | safe }}
   </article>
 
@@ -63,7 +63,7 @@ eleventyComputed:
     {% set twitterShareText %}{{ title }} by – @robsterlini{% endset %}
     {% set githubEntryUrl %}{{ global.github.branchUrl }}{{ page.inputPath.slice(1) }}{% endset %}
 
-    <div class="post-pagination__page">
+    <div class="post-pagination__page links--external">
       <h3 class="p lead">Thank you!</h3>
       <p>Firstly, thanks for taking the time to read this&nbsp;entry.</p>
       <p>If you enjoyed this post, and think others would benefit from reading it then feel free to <a href="https://twitter.com/share?text={{ twitterShareText | urlencode }}&url={{ page.url | url | absoluteUrl(global.url) | urlencode }}" target="_blank" rel="noopener" title="Share this entry on Twitter">share it on Twitter</a> (or elsewhere). I’m always up for a discussion about anything I’ve written too, so <a href="/#contact">get in touch</a> if you want to&nbsp;chat!</p>

--- a/src/_includes/pages/now.scss
+++ b/src/_includes/pages/now.scss
@@ -23,6 +23,7 @@
   }
 
   &__season {
+    font-size: 0.875rem;
 
     &--2 {
       color: var(--c-bC-33);

--- a/src/_includes/pages/now.scss
+++ b/src/_includes/pages/now.scss
@@ -26,7 +26,7 @@
     font-size: 0.875rem;
 
     &--2 {
-      color: var(--c-bC-33);
+      color: var(--c-bC-66);
     }
   }
 }

--- a/src/_includes/pages/post.scss
+++ b/src/_includes/pages/post.scss
@@ -88,7 +88,7 @@
     }
 
     &--current {
-      color: var(--c-bC-33);
+      color: var(--c-bC-66);
 
       a {
         text-decoration-color: currentColor;

--- a/src/_includes/scss/_alert.scss
+++ b/src/_includes/scss/_alert.scss
@@ -1,6 +1,7 @@
 .alert {
   border-radius: 2px;
   display: table;
+  line-height: $line-height-body-small;
   font-size: 1rem;
   font-weight: 500;
   padding: 0em 0 0.1em 0.5em;
@@ -15,5 +16,9 @@
     left: 0;
     width: 2px;
     border-radius: 1px;
+  }
+
+  .lead {
+    display: block;
   }
 }

--- a/src/_includes/scss/_base.scss
+++ b/src/_includes/scss/_base.scss
@@ -130,7 +130,7 @@ body {
   width: 92%;
 
   &--thin {
-    width: 60rem;
+    max-width: 60rem;
   }
 }
 
@@ -156,7 +156,10 @@ a,
   }
 
   abbr {
-    text-decoration: none; // Prevents a strange double line from being rendered
+    // Prevents a strange double line from being rendered
+    text-decoration: none !important;
+    border: 0 !important;
+    text-underline-position: unset !important;
   }
 
   &:hover,

--- a/src/_includes/scss/_base.scss
+++ b/src/_includes/scss/_base.scss
@@ -23,6 +23,12 @@ html, body {
   --c-cC: #FFF; // Contrast Color
   --c-cC-semi: #{rgba(#FFF, 0.66)};
   --c-cA: #{lighten(#f75c6a, 10%)}; // Contrast Accent
+
+  --c-twitter: #00ACEE;
+  --c-github: #79b8ff;
+  --c-fueled: #{lighten(#AE0000, 10%)};
+  --c-netlify: #{lighten(#15847d, 10%)};
+  --c-linkedin: #{lighten(#0077b5, 10%)};
 }
 
 @mixin light-colors {
@@ -43,6 +49,12 @@ html, body {
   --c-cC: #000;
   --c-cC-semi: #{rgba(#000, 0.66)};
   --c-cA: #{darken(#EA3243, 20%)};
+
+  --c-twitter: #00ACEE;
+  --c-github: #0366D6;
+  --c-fueled: #AE0000;
+  --c-netlify: #15847d;
+  --c-linkedin: #0077b5;
 }
 
 @mixin contrast-colors {
@@ -74,6 +86,8 @@ html, body {
 
 @include prefers-high-contrast {
   @include contrast-colors;
+
+  --link-state-color: var(--c-bC);
 }
 
 html {
@@ -134,18 +148,67 @@ body {
   }
 }
 
+[href*="twitter.com"] {
+  --link-color: var(--c-twitter);
+}
+
+[href*="github.com"] {
+  --link-color: var(--c-github);
+}
+
+[href*="fueled.com"] {
+  --link-color: var(--c-fueled);
+}
+
+[href*="tutsplus.com"] {
+  --link-color: #82b541;
+}
+
+[href*="instagram.com"] {
+  --link-color: #f00075;
+}
+
+[href*="netlify.com"],
+[href*="netlify.app"] {
+  --link-color: var(--c-netlify);
+}
+
+[href*="11ty.dev"] {
+  --link-color: #00BCD4;
+}
+
+[href*="strava.com"] {
+  --link-color: #fc4c02;
+}
+
+[href*="codepen.io"] {
+  --link-color: #0ebeff;
+}
+
+[href*="linkedin.com"] {
+  --link-color: var(--c-linkedin);
+}
+
+[href*="spotify.com"] {
+  --link-color: #1db954;
+}
+
+[href*="youtube.com"] {
+  --link-color: #FF0000;
+}
+
 a,
 .link {
   appearance: none;
   background: none;
-  color: inherit;
+  color: var(--link-state-color, inherit);
   cursor: pointer;
   font: inherit;
   font-weight: 500;
   transition: 125ms ease-in-out;
   transition-property: color, opacity, text-decoration-color;
   text-decoration: underline;
-  text-decoration-color: var(--c-bC-66, currentColor);
+  text-decoration-color: var(--link-state-color, var(--c-bC-66, currentColor));
   padding: unset;
   border: 0;
 
@@ -164,9 +227,7 @@ a,
 
   &:hover,
   &:focus {
-    color: var(--c-bA);
-    text-decoration-color: currentColor;
-    border: 0;
+    --link-state-color: var(--c-bA);
   }
 
   &:focus {
@@ -176,6 +237,39 @@ a,
   &:active {
     opacity: 0.66;
   }
+}
+
+@mixin link-external {
+
+  &::after {
+    color: var(--link-state-color, var(--link-color, var(--c-bA)));
+    content: '\00A0↗';
+    font-family: 'rsa-body', sans-serif;
+    font-weight: 500;
+    font-style: normal;
+    letter-spacing: -0.15em;
+    margin-right: 0.15em;
+    transition: color 125ms ease-in-out;
+    text-decoration: underline;
+    text-decoration-color: var(--c-bB) !important;
+  }
+
+  &:hover,
+  &:focus {
+
+    &::after {
+      color: var(--link-state-color);
+    }
+  }
+}
+
+.link--external {
+  @include link-external;
+}
+
+.links--external [href^="https://"],
+.links--external [href^="http://"] {
+  @include link-external;
 }
 
 .link--pseudo {
@@ -188,22 +282,34 @@ a,
     text-decoration: none;
     transition: none;
   }
+
+  &:hover,
+  &:focus {
+    --link-state-color: var(--c-bA);
+  }
+
+  &.link--external {
+
+    &::after {
+      display: none;
+    }
+  }
 }
 
 .link__pseudo {
+  color: var(--link-state-color);
   text-decoration: underline;
-  text-decoration-color: var(--c-bC-66, currentColor);
+  text-decoration-color: var(--link-state-color, var(--c-bC-66, currentColor));
   transition: 125ms ease-in-out;
   transition-property: color, opacity, text-decoration-color;
 
-  .link--pseudo:hover &,
-  .link--pseudo:focus & {
-    color: var(--c-bA);
-    text-decoration-color: currentColor;
-  }
-
   .link--pseudo:active & {
     opacity: 0.66;
+  }
+
+  .link--external[href^="https://"] &,
+  .link--external[href^="http://"] & {
+    @include link-external;
   }
 }
 

--- a/src/_includes/scss/_base.scss
+++ b/src/_includes/scss/_base.scss
@@ -29,6 +29,12 @@ html, body {
   --c-fueled: #{lighten(#AE0000, 10%)};
   --c-netlify: #{lighten(#15847d, 10%)};
   --c-linkedin: #{lighten(#0077b5, 10%)};
+  --c-codepen: #fefefe;
+  --c-strava: #{mix(#fc4c02, yellow, 90%)};
+  --c-envato: #82b541;
+  --c-instagram: #f00075;
+  --c-spotify: #1db954;
+  --c-youtube: #FF0000;
 }
 
 @mixin light-colors {
@@ -50,11 +56,12 @@ html, body {
   --c-cC-semi: #{rgba(#000, 0.66)};
   --c-cA: #{darken(#EA3243, 20%)};
 
-  --c-twitter: #00ACEE;
   --c-github: #0366D6;
+  --c-strava: #fc4c02;
   --c-fueled: #AE0000;
   --c-netlify: #15847d;
   --c-linkedin: #0077b5;
+  --c-codepen: #1e1f26;
 }
 
 @mixin contrast-colors {
@@ -92,7 +99,7 @@ html, body {
 
 html {
   background: var(--c-bB);
-  line-height: 1.55; // TODO: Var
+  line-height: $line-height-body;
   font-size: 0.8125rem;
   scroll-behavior: smooth;
 
@@ -161,11 +168,11 @@ body {
 }
 
 [href*="tutsplus.com"] {
-  --link-color: #82b541;
+  --link-color: var(--c-envato);
 }
 
 [href*="instagram.com"] {
-  --link-color: #f00075;
+  --link-color: var(--c-instagram);
 }
 
 [href*="netlify.com"],
@@ -178,11 +185,11 @@ body {
 }
 
 [href*="strava.com"] {
-  --link-color: #fc4c02;
+  --link-color: var(--c-strava);
 }
 
 [href*="codepen.io"] {
-  --link-color: #0ebeff;
+  --link-color: var(--c-codepen);
 }
 
 [href*="linkedin.com"] {
@@ -190,11 +197,11 @@ body {
 }
 
 [href*="spotify.com"] {
-  --link-color: #1db954;
+  --link-color: var(--c-spotify);
 }
 
 [href*="youtube.com"] {
-  --link-color: #FF0000;
+  --link-color: var(--c-youtube);
 }
 
 a,
@@ -246,9 +253,12 @@ a,
     content: '\00A0↗';
     font-family: 'rsa-body', sans-serif;
     font-weight: 500;
+    position: relative;
+    top: -0.2em;
     font-style: normal;
     letter-spacing: -0.15em;
     margin-right: 0.15em;
+    font-size: 0.825em;
     transition: color 125ms ease-in-out;
     text-decoration: underline;
     text-decoration-color: var(--c-bB) !important;

--- a/src/_includes/scss/_figure.scss
+++ b/src/_includes/scss/_figure.scss
@@ -75,8 +75,9 @@ $figure-visible-selector: '.js--figure-visible';
   &__caption {
     background: var(--c-hB);
     color: var(--c-bC-66);
-    padding: 0.125em 0.667em 0.5em;
+    padding: 0.625em 0.667em 0.667em;
     font-size: 0.825rem;
+    line-height: 1.45;
     display: table-caption;
     caption-side: bottom;
     position: relative;

--- a/src/_includes/scss/_figure.scss
+++ b/src/_includes/scss/_figure.scss
@@ -102,5 +102,11 @@ $figure-visible-selector: '.js--figure-visible';
     color: var(--c-bC-66);
     font-variant-caps: small-caps;
     text-transform: lowercase;
+
+    &:hover,
+    &:focus {
+      --link-state-color: var(--c-bC);
+      color: var(--c-bC);
+    }
   }
 }

--- a/src/_includes/scss/_figure.scss
+++ b/src/_includes/scss/_figure.scss
@@ -77,7 +77,7 @@ $figure-visible-selector: '.js--figure-visible';
     color: var(--c-bC-66);
     padding: 0.625em 0.667em 0.667em;
     font-size: 0.825rem;
-    line-height: 1.45;
+    line-height: $line-height-body-small;
     display: table-caption;
     caption-side: bottom;
     position: relative;

--- a/src/_includes/scss/_hero.scss
+++ b/src/_includes/scss/_hero.scss
@@ -11,8 +11,16 @@
     flex: 1;
   }
 
-  a:not(:hover):not(:focus) {
+  a:not(:hover):not(:focus),
+  .link:not(:hover):not(:focus) {
     text-decoration-color: var(--c-bC-33);
+  }
+
+  .link--external {
+
+    &::after {
+      text-decoration-color: var(--c-hB) !important;
+    }
   }
 
   .group {

--- a/src/_includes/scss/_mixins.scss
+++ b/src/_includes/scss/_mixins.scss
@@ -39,3 +39,6 @@
 
 $grid-row-gap: 1rem;
 $grid-column-gap: 6%;
+
+$line-height-body: 1.55;
+$line-height-body-small: 1.4;

--- a/src/_includes/scss/_type.scss
+++ b/src/_includes/scss/_type.scss
@@ -50,12 +50,12 @@
   @if ($link) {
 
     a {
-      &:not(:focus):not(:hover) {
-        text-decoration-color: currentColor;
-      }
+      --link-state-color: var(--c-bA);
+      text-decoration-color: currentColor !important;
 
       &:hover,
       &:focus {
+        --link-state-color: var(--c-bC);
         color: var(--c-bC);
       }
     }

--- a/src/_includes/scss/_type.scss
+++ b/src/_includes/scss/_type.scss
@@ -48,6 +48,7 @@
   font-weight: 500;
 
   @if ($link) {
+
     a {
       &:not(:focus):not(:hover) {
         text-decoration-color: currentColor;

--- a/src/_includes/scss/_typography.scss
+++ b/src/_includes/scss/_typography.scss
@@ -34,8 +34,10 @@ del {
 }
 
 .anchor {
+  --link-state-color: var(--c-bC-33);
+
   text-decoration: none;
-  color: var(--c-bC-33, currentColor);
+  color: var(--link-state-color, var(--c-bC-33, currentColor));
   transition-property: opacity, color;
   font-weight: inherit;
   font-family: 'rsa-body', sans-serif;

--- a/src/curriculum-vitae.njk
+++ b/src/curriculum-vitae.njk
@@ -21,7 +21,7 @@ custom_css: pages/cv.scss
 {% endset %}
 {{ hero('Rob Sterlini' | safe, header='Curriculum Vitae', children=children | safe) }}
 
-<main class="main cv">
+<main class="main cv links--external">
   <div class="group">
     <div class="cv-section--elevator">
       <h2 class="h2">Get to know&nbsp;Rob</h2>
@@ -80,7 +80,7 @@ custom_css: pages/cv.scss
         <li><time class="lead" datetime="2016P730D">2016–18</time>&ensp;<a href="https://kickpush.co">Kickpush</a></li>
         <li><time class="lead" datetime="2016">2016</time>&ensp;<a href="https://www.unifie.com/">Unifie</a></li>
         <li><time class="lead" datetime="2014">2014</time>&ensp;<a href="http://www.lodge192.com/">Lion &amp; Lamb Lodge</a>, Hotspur Related, <a href="http://legonotlegos.com"><span class="sc">LEGO</span> not Legos</a></li>
-        <li><time class="lead" datetime="2013-09">2013</time>&ensp;<a href="/journal/2013/responsive-web-design-techniques">Responsive web design techniques</a> course for Envato Tuts+</li>
+        <li><time class="lead" datetime="2013-09">2013</time>&ensp;<a href="https://webdesign.tutsplus.com/courses/responsive-web-design-techniques">Responsive web design techniques</a> course for Envato Tuts+</li>
       </ul>
     </div>
 

--- a/src/curriculum-vitae.njk
+++ b/src/curriculum-vitae.njk
@@ -50,11 +50,12 @@ custom_css: pages/cv.scss
       <h3 class="h3">Fueled</h3>
 
       <p><span class="lead">In the six years at Fueled my role has evolved a lot.</span> After joining as a web designer, I transitioned into a <abbr class="sc" title="user interface">UI</abbr>-focused developer, took on management responsibilities, and was instrumental in forming a web department. Most recently I have moved into a maker role, centered around delivering the best solutions for our clients’&nbsp;problems.</p>
-      <p>I’ve worked on high-profile projects like <strong>Apple</strong> where we built a gamified knowledge center to better inform employees when selling new devices; and bringing successful life-coaching to the web for <strong>Tony Robbins’ Robbins Research Institute</strong>. Other clients include <strong>Vanity Fair</strong>, <strong>Pinterest</strong>, and&nbsp;<a href="https://omstars.com"><strong>Omstars</strong></a>.</p>
-      <p>Since joining – and with particular focus in the last few years – I have led the development on all things <a href="https://fueled.com">fueled.com</a>. In 2018 we tore everything down and set about building a component library in line with the new brand direction. Part of the challenge was convincing stakeholders of behind-the-scenes changes for a more stable code base including publishing it as a private <span class="sc">NPM</span> package for better consumption across multiple&nbsp;repositories.</p>
+      <p>I’ve worked on high-profile projects like <strong>Apple</strong> where we built a gamified knowledge center to better inform employees when selling new devices; and bringing successful life-coaching to the web for <strong>Tony Robbins’ Robbins Research Institute</strong>. Other clients include <strong>Vanity Fair</strong>, <strong>Pinterest</strong>, and&nbsp;<a href="https://omstars.com" target="_blank" rel="noopener">Omstars.</a></p>
+      <p>Since joining – and with particular focus in the last few years – I have led the development on all things <a href="https://fueled.com" target="_blank" rel="noopener">fueled.com.</a> In 2018 we tore everything down and set about building a component library in line with the new brand direction. Part of the challenge was convincing stakeholders of behind-the-scenes changes for a more stable code base including publishing it as a private <span class="sc">NPM</span> package for better consumption across multiple&nbsp;repositories.</p>
 
       <ul class="list">
-        <li><time class="lead" datetime="2019-01">2019–present</time>&ensp;Lead Frontend Engineer</li>
+        <li><time class="lead" datetime="2019-01">2020–present</time>&ensp;Lead Frontend Engineer II</li>
+        <li><time class="lead" datetime="2019-01">2019–20</time>&ensp;Lead Frontend Engineer I</li>
         <li><time class="lead" datetime="2017-01">2017–19</time>&ensp;Senior Frontend Developer</li>
         <li><time class="lead" datetime="2015-06">2015–17</time>&ensp;Frontend Developer</li>
         <li><time class="lead" datetime="2014-07">2014–15</time>&ensp;Web Designer</li>
@@ -62,9 +63,9 @@ custom_css: pages/cv.scss
 
       <h3 class="h3">University of&nbsp;Reading</h3>
 
-      <p><span class="lead">Throughout my degree I worked closely with the in-house design team,</span> and upon graduating was offered a full-time role as the new digital designer tasked with overhauling the core information pages on&nbsp;<a href="https://reading.ac.uk">reading.ac.uk</a>.</p>
+      <p><span class="lead">Throughout my degree I worked closely with the in-house design team,</span> and upon graduating was offered a full-time role as the new digital designer tasked with overhauling the core information pages on&nbsp;<a href="https://reading.ac.uk" target="_blank" rel="noopener">reading.ac.uk.</a></p>
       <p>With a bit of project scope creep, I ended up being the sole designer and developer associated with a complete redesign and redevelopment of the main university pages concerned with attracting prospective students and improving current student&nbsp;experience.</p>
-      <p>The templates built in 2013 have stood the test of time are still used on parts of the site like the&nbsp;<a href="https://reading.ac.uk/library">library</a>.</p>
+      <p>The templates built in 2013 have stood the test of time are still used on parts of the such as the <a href="https://reading.ac.uk/library" target="_blank" rel="noopener">library&nbsp;pages.</a></p>
 
       <ul class="list">
         <li><time class="lead" datetime="2013-06P365D">2013–14</time>&ensp;Digital Designer</li>
@@ -75,11 +76,11 @@ custom_css: pages/cv.scss
       <p><span class="lead">While at university and since,</span> I have taken on select freelance projects to finance my bike obsession! I’ve built agency web presences for <strong>Kickpush</strong>, rebranded sports personalities like <strong>Hotspur Related</strong>, and – for a while – ran a successful channel on YouTube centered around designing brand identities for famous content creators like&nbsp;KSI. There are also fun side projects – like my dad’s pizza recipe birthday microsite and a <span class="sc">LEGO</span> naming pointer – in the list&nbsp;below:</p>
 
       <ul class="list">
-        <li><time class="lead" datetime="2020">2020</time>&ensp;Mamma’s Ricette <span class="lead">(Coming soon)</span></li>
-        <li><time class="lead" datetime="2019-01">2019</time>&ensp;<a href="https://ourdadmakes.pizza">Our dad makes pizza</a></li>
-        <li><time class="lead" datetime="2016P730D">2016–18</time>&ensp;<a href="https://kickpush.co">Kickpush</a></li>
-        <li><time class="lead" datetime="2016">2016</time>&ensp;<a href="https://www.unifie.com/">Unifie</a></li>
-        <li><time class="lead" datetime="2014">2014</time>&ensp;<a href="http://www.lodge192.com/">Lion &amp; Lamb Lodge</a>, Hotspur Related, <a href="http://legonotlegos.com"><span class="sc">LEGO</span> not Legos</a></li>
+        <li><time class="lead" datetime="2020">2020</time>&ensp;<a href="http://legonotlegos.com" target="_blank" rel="noopener"><span class="sc">LEGO</span> not Legos</a>, Mamma’s Ricette <span class="lead">(Coming soon)</span></li>
+        <li><time class="lead" datetime="2019-01">2019</time>&ensp;<a href="https://ourdadmakes.pizza" target="_blank" rel="noopener">Our dad makes pizza</a></li>
+        <li><time class="lead" datetime="2018">2018</time>&ensp;<a href="https://kickpush.co" target="_blank" rel="noopener">Kickpush</a></li>
+        <li><time class="lead" datetime="2016">2016</time>&ensp;<a href="https://www.unifie.com/" target="_blank" rel="noopener">Unifie</a></li>
+        <li><time class="lead" datetime="2014">2014</time>&ensp;<a href="http://www.lodge192.com/" target="_blank" rel="noopener">Lion &amp; Lamb Lodge</a>, Hotspur Related</li>
         <li><time class="lead" datetime="2013-09">2013</time>&ensp;<a href="https://webdesign.tutsplus.com/courses/responsive-web-design-techniques">Responsive web design techniques</a> course for Envato Tuts+</li>
       </ul>
     </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -14,20 +14,20 @@ custom_css: pages/home.scss
 
 {{ hero(h1 | safe, header='Rob Sterlini') }}
 
-<main class="main home-content">
+<main class="main home-content links--external">
   <div class="home-content__wrapper group">
     <div class="home-content__section--work">
-      <p class="p"><span class="lead" id="work">By day I am a Lead Frontend Engineer at <a href="https://fueled.com/team/rob-sterlini" target="_blank" rel="noopener">Fueled</a>.</span> In&nbsp;the six years I have been at Fueled, I have led the development on projects for <strong>Apple</strong>, crafted digital experiences for global personalities like <strong>Tony Robbins</strong>, and developed innovative web presences for fledgling start-ups like <strong>Keetoo</strong>, and&nbsp;<strong>Omstars</strong>.</p>
+      <p class="p"><span class="lead" id="work">By day I am a Lead Frontend Engineer at <a href="https://fueled.com/team/rob-sterlini" target="_blank" rel="noopener">Fueled.</a></span> In&nbsp;the six years I have been at Fueled, I have led the development on projects for <strong>Apple</strong>, crafted digital experiences for global personalities like <strong>Tony Robbins</strong>, and developed innovative web presences for fledgling start-ups like <strong>Keetoo</strong>, and&nbsp;<strong>Omstars</strong>.</p>
       <p>In 2018, I began spearheading the rebuild of <a href="https://fueled.com"><strong>fueled.com</strong></a> underpinned by an extensible, consistent Vue.js component library that aligned with a brand refresh within the&nbsp;organisation.</p>
     </div>
     <div class="home-content__section--life">
       <p><span class="lead" id="life">Away from the screen I like swimming, cycling, and running&hellip;</span> occasionally one after the other. I&apos;ve been participating in triathlon since 2015 and have <a href="https://www.instagram.com/p/BZJncXEAQgv/" target="_blank" rel="noopener">one <abbr title="Ironman 70.3" class="sc">IM&nbsp;70.3</abbr></a> under my belt with my sights firmly set on a full Ironman in&nbsp;2021.</p>
       <p>I&apos;m pretty into <span class="sc">LEGO</span> – you might have heard me banging the <a href="http://legonotlegos.com" target="_blank" rel="noopener"><span class="sc">LEGO</span>&nbsp;not&nbsp;Legos</a> drum on Twitter, where you&apos;d also find me tweeting about my beloved&nbsp;Spurs.</p>
-      <p>When the season is right I love outdoor activities like <a href="https://www.instagram.com/p/B817xBVnd_-/" target="_blank" rel="noopener">skiing</a>, hiking, and recently <a href="https://www.instagram.com/p/B7_0MLWn_ii/" target="_blank" rel="noopener">scuba&nbsp;diving!</a></p>
+      <p>When the season is right I love outdoor activities like <a href="https://www.instagram.com/p/B817xBVnd_-/" target="_blank" rel="noopener">skiing,</a> <a href="https://www.instagram.com/p/CDZj--_HLr5/" target="_blank" rel="noopener">hiking</a>, and recently <a href="https://www.instagram.com/p/B7_0MLWn_ii/" target="_blank" rel="noopener">scuba&nbsp;diving!</a></p>
     </div>
     <div class="home-content__section--contact">
-      <p><span class="lead" id="contact">Wanna say hi?</span> Email&nbsp;me at <a href="mailto:hi@robsterlini.co.uk">hi@robsterlini.co.uk</a> or tweet me at&nbsp;<a href="https://twitter.com/robsterlini" target="_blank" rel="noopener">@robsterlini</a>.</p>
-      <p>You can find my photos on <a href="https://instagram.com/robsterlini" target="_blank" rel="noopener">Instagram</a>, code on <a href="https://github.com/robsterlini" target="_blank" rel="noopener">Github</a>, activities on <a href="https://www.strava.com/athletes/6578573" target="_blank" rel="noopener">Strava</a>, experiments on <a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Codepen</a>, my job history on <a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">LinkedIn</a>, and <a href="/curriculum-vitae">my&nbsp;<abbr title="Curriculum vitae" class="sc">CV</abbr></a>.</p>
+      <p><span class="lead" id="contact">Wanna say hi?</span> Email&nbsp;me at <a href="mailto:hi@robsterlini.co.uk">hi@robsterlini.co.uk</a> or tweet me at&nbsp;<a href="https://twitter.com/robsterlini" target="_blank" rel="noopener">@robsterlini.</a></p>
+      <p>You can find my photos on <a href="https://instagram.com/robsterlini" target="_blank" rel="noopener">Instagram,</a> code on <a href="https://github.com/robsterlini" target="_blank" rel="noopener">Github,</a> activities on <a href="https://www.strava.com/athletes/6578573" target="_blank" rel="noopener">Strava,</a> experiments on <a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Codepen,</a> my job history on <a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">LinkedIn,</a> and <a href="/curriculum-vitae">my&nbsp;<abbr title="Curriculum vitae" class="sc">CV</abbr></a>.</p>
 
       {#<p>You can <a href="/">check out my&nbsp;<abbr title="Curriculum vitae" class="sc">CV</abbr></a>. Elsewhere on the internet you can find&nbsp;my:</p>
       <ul class="list">

--- a/src/index.njk
+++ b/src/index.njk
@@ -29,7 +29,7 @@ custom_css: pages/home.scss
     </div>
     <div class="home-content__section--contact">
       <p><span class="lead" id="contact">Wanna say hi?</span> Email&nbsp;me at <a href="mailto:hi@robsterlini.co.uk" class="link--external" title="Opens default email client">hi@robsterlini.co.uk</a> or send me a tweet me at&nbsp;<a href="https://twitter.com/robsterlini" target="_blank" rel="noopener">@robsterlini.</a></p>
-      <p>You can find my photos on <a href="https://instagram.com/robsterlini" target="_blank" rel="noopener">Instagram,</a> code on <a href="https://github.com/robsterlini" target="_blank" rel="noopener">Github,</a> activities on <a href="https://www.strava.com/athletes/6578573" target="_blank" rel="noopener">Strava,</a> experiments on <a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Codepen,</a> my job history on <a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">LinkedIn.</a></p>
+      <p>You can find my photos on <a href="https://instagram.com/robsterlini" target="_blank" rel="noopener">Instagram,</a> code on <a href="https://github.com/robsterlini" target="_blank" rel="noopener">Github,</a> training activities on <a href="https://www.strava.com/athletes/6578573" target="_blank" rel="noopener">Strava,</a> experiments on <a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Codepen,</a> my employment history on&nbsp;<a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">LinkedIn.</a></p>
 
       <p><span class="lead">Read the latest journal entry:</span> {% journalEntryShort collections.entries[0], true %}; or peruse <a href="/journal/">the older&nbsp;entries.</a></p>
     </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -19,27 +19,19 @@ custom_css: pages/home.scss
     <div class="home-content__section--work">
       <p class="p"><span class="lead" id="work">By day I am a Lead Frontend Engineer at <a href="https://fueled.com/team/rob-sterlini" target="_blank" rel="noopener">Fueled.</a></span> In&nbsp;the six years I have been at Fueled, I have led the development on projects for <strong>Apple</strong>, crafted digital experiences for global personalities like <strong>Tony Robbins</strong>, and developed innovative web presences for fledgling start-ups like <strong>Keetoo</strong>, and&nbsp;<strong>Omstars</strong>.</p>
       <p>In 2018, I began spearheading the rebuild of <a href="https://fueled.com"><strong>fueled.com</strong></a> underpinned by an extensible, consistent Vue.js component library that aligned with a brand refresh within the&nbsp;organisation.</p>
+      <p>You can find out more about my time at Fueled and before in <a href="/curriculum-vitae">my&nbsp;<abbr title="Curriculum vitae" class="sc">CV</abbr>.</a></p>
     </div>
     <div class="home-content__section--life">
-      <p><span class="lead" id="life">Away from the screen I like swimming, cycling, and running&hellip;</span> occasionally one after the other. I&apos;ve been participating in triathlon since 2015 and have <a href="https://www.instagram.com/p/BZJncXEAQgv/" target="_blank" rel="noopener">one <abbr title="Ironman 70.3" class="sc">IM&nbsp;70.3</abbr></a> under my belt with my sights firmly set on a full Ironman in&nbsp;2021.</p>
-      <p>I&apos;m pretty into <span class="sc">LEGO</span> – you might have heard me banging the <a href="http://legonotlegos.com" target="_blank" rel="noopener"><span class="sc">LEGO</span>&nbsp;not&nbsp;Legos</a> drum on Twitter, where you&apos;d also find me tweeting about my beloved&nbsp;Spurs.</p>
-      <p>When the season is right I love outdoor activities like <a href="https://www.instagram.com/p/B817xBVnd_-/" target="_blank" rel="noopener">skiing,</a> <a href="https://www.instagram.com/p/CDZj--_HLr5/" target="_blank" rel="noopener">hiking</a>, and recently <a href="https://www.instagram.com/p/B7_0MLWn_ii/" target="_blank" rel="noopener">scuba&nbsp;diving!</a></p>
+      <p><span class="lead" id="life">Away from the screen I like swimming, cycling, and running&hellip;</span> occasionally one after the other. I’ve been participating in triathlon since 2015 and have <a href="https://www.instagram.com/p/BZJncXEAQgv/" target="_blank" rel="noopener">one <abbr title="Ironman 70.3" class="sc">IM&nbsp;70.3</abbr></a> under my belt with my sights firmly set on a full distance Ironman in&nbsp;2021.</p>
+      <p>I’m pretty into <span class="sc">LEGO</span> – you might have heard me banging the <a href="http://legonotlegos.com" target="_blank" rel="noopener"><span class="sc">LEGO</span>&nbsp;not&nbsp;Legos</a> drum on Twitter, where you’d also find me tweeting about my beloved&nbsp;Spurs.</p>
+      <p>When the season is right I love outdoor activities like <a href="https://www.instagram.com/p/B817xBVnd_-/" target="_blank" rel="noopener">skiing,</a> <a href="https://www.instagram.com/p/CDZj--_HLr5/" target="_blank" rel="noopener">hiking,</a> and recently <a href="https://www.instagram.com/p/B7_0MLWn_ii/" target="_blank" rel="noopener">scuba&nbsp;diving!</a></p>
+      <p>If you’re really curious, you can find out what I’m up to&nbsp;<a href="/now">now.</a></p>
     </div>
     <div class="home-content__section--contact">
-      <p><span class="lead" id="contact">Wanna say hi?</span> Email&nbsp;me at <a href="mailto:hi@robsterlini.co.uk">hi@robsterlini.co.uk</a> or tweet me at&nbsp;<a href="https://twitter.com/robsterlini" target="_blank" rel="noopener">@robsterlini.</a></p>
-      <p>You can find my photos on <a href="https://instagram.com/robsterlini" target="_blank" rel="noopener">Instagram,</a> code on <a href="https://github.com/robsterlini" target="_blank" rel="noopener">Github,</a> activities on <a href="https://www.strava.com/athletes/6578573" target="_blank" rel="noopener">Strava,</a> experiments on <a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Codepen,</a> my job history on <a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">LinkedIn,</a> and <a href="/curriculum-vitae">my&nbsp;<abbr title="Curriculum vitae" class="sc">CV</abbr></a>.</p>
+      <p><span class="lead" id="contact">Wanna say hi?</span> Email&nbsp;me at <a href="mailto:hi@robsterlini.co.uk" class="link--external" title="Opens default email client">hi@robsterlini.co.uk</a> or send me a tweet me at&nbsp;<a href="https://twitter.com/robsterlini" target="_blank" rel="noopener">@robsterlini.</a></p>
+      <p>You can find my photos on <a href="https://instagram.com/robsterlini" target="_blank" rel="noopener">Instagram,</a> code on <a href="https://github.com/robsterlini" target="_blank" rel="noopener">Github,</a> activities on <a href="https://www.strava.com/athletes/6578573" target="_blank" rel="noopener">Strava,</a> experiments on <a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Codepen,</a> my job history on <a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">LinkedIn.</a></p>
 
-      {#<p>You can <a href="/">check out my&nbsp;<abbr title="Curriculum vitae" class="sc">CV</abbr></a>. Elsewhere on the internet you can find&nbsp;my:</p>
-      <ul class="list">
-        <li><a href="https://instagram.com/robsterlini" target="_blank" rel="noopener">Photos on Instagram</a></li>
-        <li><a href="https://github.com/robsterlini" target="_blank" rel="noopener">Code on Github</a></li>
-        <li><a href="https://www.strava.com/athletes/6578573" target="_blank" rel="noopener">Activities on Strava</a></li>
-        <li><a href="https://codepen.io/robsterlini/" target="_blank" rel="noopener">Experiments on Codepen</a></li>
-        <li><a href="https://www.linkedin.com/in/robsterlini/" target="_blank" rel="noopener">History on LinkedIn</a></li>
-      </ul>#}
-      {% set entry = collections.entries[0] %}
-
-      <p><span class="lead">Read the latest journal entry:</span> {% journalEntryShort entry, true %}; or peruse <a href="/journal/">the older&nbsp;entries</a>.</p>
+      <p><span class="lead">Read the latest journal entry:</span> {% journalEntryShort collections.entries[0], true %}; or peruse <a href="/journal/">the older&nbsp;entries.</a></p>
     </div>
   </div>
 </main>

--- a/src/journal/2014/opentype-and-selection-dont-mix.md
+++ b/src/journal/2014/opentype-and-selection-dont-mix.md
@@ -1,5 +1,5 @@
 ---
-title: Opentype and ::selection don’t mix
+title: Opentype & ::selection don’t mix
 date: 2014-04-29
 description: Fixing the dubious way that Chrome on <abbr title="Mac OS X" class="sc">OSX</abbr> borks OpenType features when used with a custom ::selection.
 layout: post
@@ -90,7 +90,7 @@ p {
 }
 ```
 
-It would also mean sacrificing the tasty features on all the other browsers, but *A List Apart* had a similar issue and solved it with [a bit of JS browser-sniffing](https://github.com/alistapart/AListApart/issues/53 "Find out how A List Apart fixed it"):
+It would also mean sacrificing the tasty features on all the other browsers, but *A List Apart* had a similar issue and solved it with [a bit of JS browser-sniffing:](https://github.com/alistapart/AListApart/issues/53 "Find out how A List Apart fixed it")
 
 ```js
 var b = document.documentElement;
@@ -161,4 +161,4 @@ Feel free to use any of the techniques shown until Chrome fix it, happy OpenType
 
 ## Let Google know
 
-A while back I added this as a Chromium issue, but it seems to have lost traction so if you can [star the bug](https://code.google.com/p/chromium/issues/detail?id=362956 "See the Chromium Issue raised on this subject"), so we can get this fixed that’d be grand!
+A while back I added this as a Chromium issue, but it seems to have lost traction so if you can [star the bug,](https://code.google.com/p/chromium/issues/detail?id=362956 "See the Chromium Issue raised on this subject") so we can get this fixed that’d be grand!

--- a/src/journal/2015/triathlete.md
+++ b/src/journal/2015/triathlete.md
@@ -11,7 +11,7 @@ tags:
 
 ## Why triathlon?
 
-When I signed up for [The London Triathlon](/triathlon/#the-london-triathlon "Read about my reasons for doing The London Triathlon"), I had no experience in the sport. At&nbsp;all.
+When I signed up for [The London Triathlon,](/triathlon/#the-london-triathlon "Read about my reasons for doing The London Triathlon") I had no experience in the sport. At&nbsp;all.
 
 I learned to swim at an early age; I learned to ride a bike at an early age; and a little more recently I’ve taken up running as a way to keep fit (you’ll probably have seen many of the countless Nike+ runs on [my Instagram feed](https://instagram.com/robsterlini "Check out my photos on Instagram")).
 
@@ -32,13 +32,13 @@ Triathlon was perfect.
 
 ### How do you prepare for a triathlon?
 
-So I started training the three disciplines: pushing out my runs to regularly hit [half](https://instagram.com/p/xbnc-DP-9e/?taken-by=robsterlini "Check out my run on 4 January") [marathon](https://instagram.com/p/3gJcbmP-9C/?taken-by=robsterlini "Check out my run on 4 June") [distances](https://instagram.com/p/4RJdMDv-_8/?taken-by=robsterlini "Check out my run on 23 June"); jumping onto my bike more and more, including cyclo-commuting on a daily basis – culminating in a [105.9km ride](https://instagram.com/p/4e_9dyP-_A/?taken-by=robsterlini "Check out my longest ride to date"); and I even got some open water practice in with the [Swim Dem Crew](https://instagram.com/p/3lTk5Gv-4L/?taken-by=robsterlini "Check out the photos from my first trip to the Reservoir") at the West Reservoir.
+So I started training the three disciplines: pushing out my runs to regularly hit [half](https://instagram.com/p/xbnc-DP-9e/?taken-by=robsterlini "Check out my run on 4 January") [marathon](https://instagram.com/p/3gJcbmP-9C/?taken-by=robsterlini "Check out my run on 4 June") [distances;](https://instagram.com/p/4RJdMDv-_8/?taken-by=robsterlini "Check out my run on 23 June") jumping onto my bike more and more, including cyclo-commuting on a daily basis – culminating in a [105.9km ride;](https://instagram.com/p/4e_9dyP-_A/?taken-by=robsterlini "Check out my longest ride to date") and I even got some open water practice in with the [Swim Dem Crew](https://instagram.com/p/3lTk5Gv-4L/?taken-by=robsterlini "Check out the photos from my first trip to the Reservoir") at the West Reservoir.
 
 The plan was never to use a specific training regime; but instead to just push each of the disciplines and improve as much as I could before the weekend of the first triathlon, and then just go and enjoy it as slowly or as quickly as it unfolded.
 
 ## The day itself
 
-Having trained as much as the time would allow, it was time to do a [final gear check](https://instagram.com/p/4-K7NFv-78/?taken-by=robsterlini "Check out my final gear check on Instagram"), pack it all up and head out to Derby.
+Having trained as much as the time would allow, it was time to do a [final gear check,](https://instagram.com/p/4-K7NFv-78/?taken-by=robsterlini "Check out my final gear check on Instagram") pack it all up and head out to Derby.
 
 I’d signed up for the [Jenson Button Trust Triathlon](http://www.jensonbuttontri.com/ "Check out the official Jenson Button Trust Triathlon website") as a warmup for London, but kne,w very little about it. It was an event sponsored by [HUUB](http://huubdesign.com "Check out the HUUB website") – the makers of my wetsuit, so that seemed a good enough reason to give it a shot.
 
@@ -61,7 +61,7 @@ My first triathlon.
 
 I’ve never racked a bike before, so I made sure I was there early. I was there a full two and a half hours before my wave time to get everything sorted – and naturally was within the first four or five people there.
 
-As more people flooded in, I sat and watched how others set up their (very expensive-looking wheels), and adjusted mine accordingly. I did, however, forget that if I wore my running shoes to the event… that when they had to stay in transition ahead of the race, I would be left without anything on my feet. One to remember for next time, I think!
+As more people flooded in, I sat and watched how others set up their (very expensive-looking) wheels, and adjusted mine accordingly. I did, however, forget that if I wore my running shoes to the event… that when they had to stay in transition ahead of the race, I would be left without anything on my feet. One to remember for next time, I think!
 
 ### The swim
 
@@ -146,7 +146,7 @@ The tears of pain from the first time round came back again, but as those ‘can
 
 So how was it overall?
 
-> Excuse my language, but f**k me that was fun! What an experience! [#triathlonvirginity](https://twitter.com/hashtag/triathlonvirginity?src=hash) [@JBTrustTri](https://twitter.com/JBTrustTri). <cite>[@robsterlini](https://twitter.com/robsterlini/status/620171205178433536)</cite>
+> Excuse my language, but f**k me that was fun! What an experience! [#triathlonvirginity](https://twitter.com/hashtag/triathlonvirginity?src=hash) [@JBTrustTri.](https://twitter.com/JBTrustTri) <cite>[@robsterlini](https://twitter.com/robsterlini/status/620171205178433536)</cite>
 
 __Unbelievable!__
 

--- a/src/journal/2016/parkrun-changed-my-life.md
+++ b/src/journal/2016/parkrun-changed-my-life.md
@@ -29,9 +29,9 @@ This is when it all started. Looking in the mirror and having this fella stare b
 
 There are lots of reasons that it got this way, but living a student’s life with a worker’s income just meant lots of fast food; which combined with little to no exercise ended me up here.
 
-I [moved home to London](/journal/good-bye-reading/), [started a new job](/journal/new-stuff/), and enlisted the help of an amazing personal trainer, and set about changing the way I was living.
+I [moved home to London,](/journal/good-bye-reading/) [started a new job,](/journal/new-stuff/) and enlisted the help of an amazing personal trainer, and set about changing the way I was living.
 
-One of the things that I introduced into my life was [parkrun](http://www.parkrun.org.uk/).
+One of the things that I introduced into my life was [parkrun.](http://www.parkrun.org.uk/)
 
 ## Cue parkrun
 
@@ -58,19 +58,19 @@ When I moved to South London over a year ago now, I was in prime location for ru
   "This wonder-woman of a mum and I cruised personal bests at the RPF Half in October 2015"
 %}
 
-Last year, the two (well three) triathlons I did went [really](/journal/triathlete/) [well](/journal/the-london-triathon/), the Tough Mudders went well, and the [Royal Parks Half Marathon](https://www.instagram.com/p/8tJztOP-yZ/?taken-by=robsterlini) went exceptionally well!
+Last year, the two (well three) triathlons I did went [really](/journal/triathlete/) [well,](/journal/the-london-triathon/) the Tough Mudder events went well, and the [Royal Parks Half Marathon](https://www.instagram.com/p/8tJztOP-yZ/?taken-by=robsterlini) went exceptionally well!
 
 The RPF half was a fantastic day. Hitting a half marathon PB of 1:44; cheering my mum over the line as she smashed her own PB, and rounding off the perfect season of progress.
 
 ## Run Dem Crew
 
-Okay so maybe it wasn’t running that changed my life.
+Okay so maybe it wasn’t running that changed my life.
 
-Maybe it was Run Dem Crew that changed my life.
+Maybe it was Run Dem Crew that changed my life.
 
-Running on a Tuesday with likeminded, diverse, and wonderful people was a catalyst to reducing __all__ of my personal bests – culminating in [a 1:34 <abbr title="personal best">PB</abbr> at the North London Half](https://www.instagram.com/p/BDLQv_iv-_m/?taken-by=robsterlini).
+Running on a Tuesday with likeminded, diverse, and wonderful people was a catalyst to reducing __all__ of my personal bests – culminating in [a 1:34 <abbr title="personal best">PB</abbr> at the North London Half.](https://www.instagram.com/p/BDLQv_iv-_m/?taken-by=robsterlini)
 
-I set a New Year’s run-spiriation with a first footing run on 1 January (cheers Sarah _et al_):
+I set a New Year’s run-spiriation with a first footing run on 1&nbsp;January (cheers Sarah _et al_):
 
 > Miles and smiles. Enjoy every run, and be grateful that you’re able to do this!
 
@@ -139,7 +139,7 @@ I went back to Derby to take on the Jenson Button Trust Triathlon again – and 
 
 That was just the warm up for this weekend though. Sunday is the big one.
 
-My second London Triathlon, but I’m moving up to the big boy leagues – it’s time for my first olympic distance. 1500m of salty Thames water; 40km of rolling roads on [Alice](https://www.instagram.com/p/BGhNLCmv-9y/?taken-by=robsterlini); and then the small task of a 10km run to round it all off!
+My second London Triathlon, but I’m moving up to the big boy leagues – it’s time for my first olympic distance. 1500m of salty Thames water; 40km of rolling roads on [Alice;](https://www.instagram.com/p/BGhNLCmv-9y/?taken-by=robsterlini) and then the small task of a 10km run to round it all off!
 
 The progress I’ve made hasn’t just been physical – although shedding 25kg to dip under 75kg and be the lightest I’ve been as a grown man. My mentalities have changed. I’ve relaxed. I’m happier. I challenge myself more because I know that I’m mentally more capable of overcoming hurdles, and I don’t give up like I used to.
 

--- a/src/journal/2020/a-fresh-lick-of-paint.md
+++ b/src/journal/2020/a-fresh-lick-of-paint.md
@@ -80,7 +80,7 @@ Well… not profit, but a build from nothing live on [robsterlini.co.uk](/) in a
 
 To really test whether I was okay shipping something unfinished, I had to release it into the wild and there’s no accountability quite like Twitter:
 
-> Soft launching a new, slim-lined [robsterlini.co.uk](http://robsterlini.co.uk) this evening! Still a bit to work on, and some more to build out, but it’s a start that I’m happy with. Holler if you notice anything out of the ordinary! <cite>[@robsterlini](https://twitter.com/robsterlini/status/1270833777997160448)</cite>
+> Soft launching a new, slim-lined [robsterlini.co.uk](/) this evening! Still a bit to work on, and some more to build out, but it’s a start that I’m happy with. Holler if you notice anything out of the ordinary! <cite>[@robsterlini](https://twitter.com/robsterlini/status/1270833777997160448)</cite>
 
 ## Next steps…
 

--- a/src/journal/2020/a-fresh-lick-of-paint.md
+++ b/src/journal/2020/a-fresh-lick-of-paint.md
@@ -9,11 +9,11 @@ tags:
 
 ‘Painting the Forth Bridge’.
 
-Turns out that, that task isn’t as endless as [we were lead to believe it&nbsp;was](https://www.bbc.co.uk/news/uk-scotland-edinburgh-east-fife-14789036)…
+Turns out that, that task isn’t as endless as [we were lead to believe it&nbsp;was…](https://www.bbc.co.uk/news/uk-scotland-edinburgh-east-fife-14789036)
 
 I’d like to lead a motion to replace it with __‘building a personal site’__.
 
-With commits like [`Hate it` from October 2019](https://github.com/robsterlini/robsterlini-frontend/commit/2d0db80d96a1f5e5978c6a09a6e3e7e6b8a97878), and a [PR named `2018`](https://github.com/robsterlini/robsterlini-frontend/pull/1) getting merged at around the same time, it’s no surprise that these tasks take so long; but extra time at home gave me the opportunity to really strip it down and start afresh.
+With commits like [`Hate it` from October 2019,](https://github.com/robsterlini/robsterlini-frontend/commit/2d0db80d96a1f5e5978c6a09a6e3e7e6b8a97878) and a [PR named `2018`](https://github.com/robsterlini/robsterlini-frontend/pull/1) getting merged at around the same time, it’s no surprise that these tasks take so long; but extra time at home gave me the opportunity to really strip it down and start afresh.
 
 ## Where to start
 
@@ -47,7 +47,7 @@ With a rough design down, and some potential typefaces chosen this would be the 
   "I cannot stress how straightforward it is to get a site live on Netlify, either with the drag and drop of files, or with an actual build pipeline."
 %}
 
-I created `~/Sites/robsterlini-2020/index.html` and just wrote classic HTML and timeless (inlined) CSS – shock, horror, it just worked! Within an hour or so I had a directory uploaded to [Netlify Drop](https://app.netlify.com/drop) and a testable and iterable [build](https://5ee125740fe15994a7992f3f--agitated-leavitt-bb4762.netlify.app/). It wasn’t clean, or extensible, but that wasn’t important.
+I created `~/Sites/robsterlini-2020/index.html` and just wrote classic HTML and timeless (inlined) CSS – shock, horror, it just worked! Within an hour or so I had a directory uploaded to [Netlify&nbsp;Drop](https://app.netlify.com/drop) and a testable and iterable [build](https://5ee125740fe15994a7992f3f--agitated-leavitt-bb4762.netlify.app/). It wasn’t clean, or extensible, but that wasn’t important.
 
 ### 4. Get it live!
 

--- a/src/journal/2020/light-and-dark-mode-plus.md
+++ b/src/journal/2020/light-and-dark-mode-plus.md
@@ -269,7 +269,7 @@ body {
 }
 ```
 
-Rather than creating `@media` combinations of `prefers-contrast` and `prefers-color-scheme`, and creating `[data-color-preference=""][data-contrast-preference="[]` declarations for every possible permutation, the `light` and `dark` colour schemes now have `-high-contrast` variants of their values which are used in the `high-contrast-colors` mixin to redefine their values (whilst maintaining the colour preference).
+Rather than creating `@media` combinations of `prefers-contrast` and `prefers-color-scheme`, and creating `[data-color-preference=""][data-contrast-preference=""]` declarations for every possible permutation, the `light` and `dark` colour schemes now have `-high-contrast` variants of their values which are used in the `high-contrast-colors` mixin to redefine their values (whilst maintaining the colour preference).
 
 This abstraction comes into its own when there are more than just `background` and `color` variables, and means a few variables can be used to keep consistent styling for every possible combiniation of colour and contrast preference throughout your site.
 
@@ -299,13 +299,13 @@ Accessibility is important, and respecting users’ defaults whilst offering ove
 
 ## Further considerations
 
-Now that we’re respecting user’s preferences over contrast and colour scheme, why not explore [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion), [`prefers-reduced-transparency`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-transparency), or any of the other user preference media queries proposed in [Media Queries Level 5](https://www.w3.org/TR/mediaqueries-5/#mf-user-preferences).
+Now that we’re respecting user’s preferences over contrast and colour scheme, why not explore [`prefers-reduced-motion`,](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) [`prefers-reduced-transparency`,](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-transparency) or any of the other user preference media queries proposed in [Media Queries Level 5.](https://www.w3.org/TR/mediaqueries-5/#mf-user-preferences)
 
 There are two things to bare in mind:
 
-1. Implementing every combination of every media query will likely lead to more code that is less maintainable
-2. A lot of the Media Queries Level 5 features are still experimental – use them at your own risk!
+1. Implementing every combination of every media query will likely lead to more code that is less maintainable
+2. A lot of the Media Queries Level 5 features are still experimental – use them at your own risk!
 
 ## Final thoughts
 
-For a full HTML example of the techniques described above, check out [this Gist]({{ global.github.branchUrl }}/gists/light-and-dark-mode-plus.html) (you can download, save it and then open the file locally in your browser with no extra steps needed). Keep in mind that there are lots of ways to neaten up the code; it is deliberately unabstracted to make it as easily understood as possible – you can see it abstracted a little and with some extra features (notably changing the `auto` label to include the user’s preference more obviously) within [the repository for this site]({{ global.github.branchUrl }}/src/_includes/layouts/base.njk). There’s also a more fully fleshed out implementation of CSS Custom Properties for colour schemes in there too.
+For a full HTML example of the techniques described above, check out [this Gist]({{ global.github.branchUrl }}/gists/light-and-dark-mode-plus.html) (you can download, save it and then open the file locally in your browser with no extra steps needed). Keep in mind that there are lots of ways to neaten up the code; it is deliberately unabstracted to make it as easily understood as possible – you can see it abstracted a little and with some extra features (notably changing the `auto` label to include the user’s preference more obviously) within [the repository for this site.]({{ global.github.branchUrl }}/src/_includes/layouts/base.njk) There’s also a more fully fleshed out implementation of CSS Custom Properties for colour schemes in there too.

--- a/src/now.njk
+++ b/src/now.njk
@@ -31,7 +31,7 @@ hero_h1: What I’m up to
 
         {% if current < 3 %}
           <div class="year__season year__season--{{ current }}">
-            <h3 class="h3" id="seasonAnchor">{{ seasonMeta.title }} <a href="#{{ seasonAnchor }}" class="anchor">&#182;</a></h3>
+            <h3 class="h3" id="{{ seasonAnchor }}">{{ seasonMeta.title }} <a href="#{{ seasonAnchor }}" class="anchor">&#182;</a></h3>
             {% if current > 1 %}
               Check back soon…
             {% else %}

--- a/src/now.njk
+++ b/src/now.njk
@@ -11,12 +11,12 @@ hero_h1: What I’m up to
 {% from "components/hero.html" import hero %}
 
 {% set children %}
-<p>With the <a href="/journal/2020/a-fresh-lick-of-paint/">new site</a> I thought it would be a good time to implement a <a href="https://nownownow.com/about/" target="_blank">nownownow.com</a> page with a bit of insight into what I’m up to in life and&nbsp;work.</p>
+<p>With the <a href="/journal/2020/a-fresh-lick-of-paint/">new site</a> I thought it would be a good time to implement a <a class="link--external" href="https://nownownow.com/about/" target="_blank">nownownow.com</a> page with a bit of insight into what I’m up to in life and&nbsp;work.</p>
 {% endset %}
 
 {{ hero(hero_h1, header=title, children=children | safe) }}
 
-<main class="main">
+<main class="main links--external">
   <div class="group">
     {% set current = 0 %}
     {% for year, seasons in now.years %}

--- a/src/now.njk
+++ b/src/now.njk
@@ -33,7 +33,7 @@ hero_h1: What I’m up to
           <div class="year__season year__season--{{ current }}">
             <h3 class="h3" id="{{ seasonAnchor }}">{{ seasonMeta.title }} <a href="#{{ seasonAnchor }}" class="anchor">&#182;</a></h3>
             {% if current > 1 %}
-              Check back soon…
+              <p>Check back soon…</p>
             {% else %}
               {% if season.life %}
                 <p><strong class="lead">In life I {{ 'was' if current == 0 else 'am' }}</strong> {{ season.life | safe   }}</p>
@@ -44,7 +44,7 @@ hero_h1: What I’m up to
               {% if season.music %}
                 <p>
                   <strong class="lead">I {{ 'was' if current == 0 else 'am' }} listening to</strong>
-                  {% set musicText %}{% if season.music.title %}{{ season.music.title }}, {% endif %}{% if season.music.artist %}<span class="regula">{{ season.music.artist }}</span>{% endif %}{% endset %}
+                  {% set musicText %}{% if season.music.title %}{{ season.music.title }}, {% endif %}{% if season.music.artist %}{{ season.music.artist }}{% endif %}.{% endset %}
                   {% if season.music.link %}
                     <a href="{{ season.music.link }}" rel="noopener" target="_blank">{{ musicText | safe }}</a>
                   {% else %}

--- a/src/now.njk
+++ b/src/now.njk
@@ -41,6 +41,16 @@ hero_h1: What I’m up to
               {% if season.work %}
                 <p><strong class="lead">At work I {{ 'was' if current == 0 else 'am' }}</strong> {{ season.work | safe   }}</p>
               {% endif %}
+              {% if season.music %}
+                <p>
+                  <strong class="lead">I {{ 'was' if current == 0 else 'am' }} listening to</strong>
+                  {% set musicText %}{% if season.music.title %}{{ season.music.title }}, {% endif %}{% if season.music.artist %}<span class="regula">{{ season.music.artist }}</span>{% endif %}{% endset %}
+                  {% if season.music.link %}
+                    <a href="{{ season.music.link }}" rel="noopener" target="_blank">{{ musicText | safe }}</a>
+                  {% else %}
+                    {{ musicText | safe }}
+                  {% endif %}
+              {% endif %}
             {% endif %}
           </div>
         {% endif %}


### PR DESCRIPTION
### What does this PR change?
Adds a visual indicator to links that go to other sites that they are external (and enforcing `target="_blank" rel="noopener"` in journal posts. All pages have been corrected (and the readme updated) to reflect the new ‘punctuation inside links’ preference.

### Does it fix any (other) issues?
* Fixes the `.group--thin` issue on small screens
* Adds a music section to each of the `/now` page seasons
* Minor copy updates across the board

### Are there any backend requirements or frontend dependencies?
* `markdown-it-link-attributes`

### How has this been tested?
Locally

### Is the Lighthouse score affected by this PR?
Nope, still [4&times;💯](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fdeploy-preview-31--robsterlini-frontend.netlify.app%2F), but the Netlify TTFB was noticeably slow in a few tests. One to keep an eye on!

:rocket:
