### PR TITLE
Fix `header` issue 🐛

### DIFF
--- a/src/_includes/components/hero.html
+++ b/src/_includes/components/hero.html
@@ -1,12 +1,12 @@
 {% macro hero(heading, header='', children='', centre=false) %}
-<div class="hero{% if children %} hero--children{% endif %}{% if centre %} hero--centre{% endif %}">
+<header class="hero{% if children %} hero--children{% endif %}{% if centre %} hero--centre{% endif %}">
   <div class="group">
-    <header class="hero__header h3">
+    <p class="hero__header h3">
       {% if header %}<span>{{ header }}</span>{% endif %}
-    </header>
+    </p>
     <h1 class="h1">{{ heading }}</h1>
     {% if children %}<div class="hero__children">{{ children }}</div>{% endif %}
   </div>
   <svg class="hero__angle" preserveAspectRatio="none" width="1000" height="50" viewBox="0 0 1000 50" xmlns="http://www.w3.org/2000/svg"><path d="M1000 0H0v50z" fill="none" fill-rule="evenodd"/></svg>
-</div>
+</header>
 {% endmacro %}

--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -2,7 +2,7 @@
   <div class="group footer__wrapper links--external">
     <div>
       <p>
-        <a href="/">Built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a>, hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify</a>, with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/" target="_blank" rel="noopener">GitHub</a>. Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta</a>, and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
+        <a href="/">Built using <a href="https://www.11ty.dev/" target="_blank" rel="noopener">Eleventy</a>, hosted on <a href="https://netlify.com" target="_blank" rel="noopener">Netlify</a>, with code available for dissection on <a href="https://github.com/robsterlini/robsterlini-frontend/" target="_blank" rel="noopener" title="View the repository on GitHub">GitHub</a>. Typefaces are by <a href="https://p22.com/family-Mackinac" target="_blank" rel="noopener">P22</a> and <a href="https://www.rosettatype.com/Clone" target="_blank" rel="noopener">Rosetta</a>, and are self&#8209;served. No cookies, no tracking, no&nbsp;nothing!
       </p>
 
       <ul class="footer__links">


### PR DESCRIPTION
### What does this PR change?
Fixes an a11y concern flagged by Axe

### Does it fix any (other) issues?
* Adds a better `title` to the duplicate ‘Github’ URL in the footer

### Are there any backend requirements or frontend dependencies?
No

### How has this been tested?
Locally

### Is the Lighthouse score affected by this PR?
No

:rocket:
